### PR TITLE
Add Mocha tests for fuel tracking utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "BeamNG fuel economy mod",
   "scripts": {
-    "test": "node tests/app.test.js"
+    "test": "mocha"
+  },
+  "devDependencies": {
+    "mocha": "^10.2.0"
   }
 }

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -10,38 +10,54 @@ const {
   calculateRange
 } = require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
 
-(function testCalculateFuelFlow() {
-  assert.strictEqual(calculateFuelFlow(10, null, 1), 0, 'handles missing previous fuel');
-  assert.strictEqual(calculateFuelFlow(10, 12, 0), 0, 'handles non-positive dt');
-  assert.strictEqual(calculateFuelFlow(10, 12, 2), 1, 'computes fuel flow');
-})();
+describe('app.js utility functions', function () {
+  describe('calculateFuelFlow', function () {
+    it('handles missing previous fuel', function () {
+      assert.strictEqual(calculateFuelFlow(10, null, 1), 0);
+    });
+    it('handles non-positive dt', function () {
+      assert.strictEqual(calculateFuelFlow(10, 12, 0), 0);
+    });
+    it('computes fuel flow', function () {
+      assert.strictEqual(calculateFuelFlow(10, 12, 2), 1);
+    });
+  });
 
-(function testCalculateInstantConsumption() {
-  assert.strictEqual(
-    calculateInstantConsumption(0.002, 20),
-    0.002 / 20 * 100000,
-    'computes instant consumption'
-  );
-  assert.strictEqual(
-    calculateInstantConsumption(0.001, 0),
-    Infinity,
-    'handles zero speed'
-  );
-})();
+  describe('calculateInstantConsumption', function () {
+    it('computes instant consumption', function () {
+      assert.strictEqual(
+        calculateInstantConsumption(0.002, 20),
+        0.002 / 20 * 100000
+      );
+    });
+    it('handles zero speed', function () {
+      assert.strictEqual(
+        calculateInstantConsumption(0.001, 0),
+        Infinity
+      );
+    });
+  });
 
-(function testTrimQueue() {
-  const queue = [];
-  for (let i = 0; i < 10; i++) queue.push(i);
-  trimQueue(queue, 5);
-  assert.strictEqual(queue.length, 5, 'queue trimmed to max entries');
-  assert.deepStrictEqual(queue, [5,6,7,8,9], 'oldest entries removed');
-})();
+  describe('trimQueue', function () {
+    it('trims oldest entries to max size', function () {
+      const queue = [];
+      for (let i = 0; i < 10; i++) queue.push(i);
+      trimQueue(queue, 5);
+      assert.strictEqual(queue.length, 5);
+      assert.deepStrictEqual(queue, [5, 6, 7, 8, 9]);
+    });
+  });
 
-(function testCalculateRange() {
-  const EPS_SPEED = 0.005;
-  assert.strictEqual(calculateRange(10, 5, 1, EPS_SPEED), 2, 'finite range computed');
-  assert.strictEqual(calculateRange(10, 0, 1, EPS_SPEED), Infinity, 'infinite range when moving with zero consumption');
-  assert.strictEqual(calculateRange(10, 0, 0, EPS_SPEED), 0, 'zero range when stopped with zero consumption');
-})();
-
-console.log('All tests passed');
+  describe('calculateRange', function () {
+    const EPS_SPEED = 0.005;
+    it('computes finite range when consuming fuel', function () {
+      assert.strictEqual(calculateRange(10, 5, 1, EPS_SPEED), 2);
+    });
+    it('computes infinite range when moving without consumption', function () {
+      assert.strictEqual(calculateRange(10, 0, 1, EPS_SPEED), Infinity);
+    });
+    it('computes zero range when stopped without consumption', function () {
+      assert.strictEqual(calculateRange(10, 0, 0, EPS_SPEED), 0);
+    });
+  });
+});

--- a/tests/cumulative.test.js
+++ b/tests/cumulative.test.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+
+// Stub minimal angular object so the module can be required in Node.
+global.angular = { module: () => ({ directive: () => ({}) }) };
+
+const { calculateFuelFlow } = require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+
+describe('cumulative tracking', function () {
+  it('tracks cumulative fuel usage and distance', function () {
+    const fuelLevels = [50, 49.9, 49.7, 49.4];
+    const dt = 1; // seconds between updates
+    const speed = 10; // constant speed m/s
+
+    let prev = fuelLevels[0];
+    let totalFuel = 0;
+    let totalDistance = 0;
+
+    for (let i = 1; i < fuelLevels.length; i++) {
+      const curr = fuelLevels[i];
+      const flow = calculateFuelFlow(curr, prev, dt); // L/s
+      totalFuel += flow * dt;
+      totalDistance += speed * dt;
+      prev = curr;
+    }
+
+    assert.strictEqual(totalFuel, 0.6);
+    assert.strictEqual(totalDistance, 30);
+  });
+});


### PR DESCRIPTION
## Summary
- use Mocha for running tests
- refactor utility tests into Mocha style
- add cumulative fuel and distance tracking test

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mocha)*
- `npm test` *(fails: mocha: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab99fd4a1483299f5d8d5d9db88f99