### PR TITLE
Add unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "description": "BeamNG fuel economy mod",
   "scripts": {
-    "test": "node tests/app.test.js"
+    "test": "node --test"
   }
 }

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1,4 +1,5 @@
-const assert = require('assert');
+const assert = require('node:assert');
+const { describe, it } = require('node:test');
 
 // Stub minimal angular object so the module can be required in Node.
 global.angular = { module: () => ({ directive: () => ({}) }) };
@@ -10,38 +11,54 @@ const {
   calculateRange
 } = require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
 
-(function testCalculateFuelFlow() {
-  assert.strictEqual(calculateFuelFlow(10, null, 1), 0, 'handles missing previous fuel');
-  assert.strictEqual(calculateFuelFlow(10, 12, 0), 0, 'handles non-positive dt');
-  assert.strictEqual(calculateFuelFlow(10, 12, 2), 1, 'computes fuel flow');
-})();
+describe('app.js utility functions', () => {
+  describe('calculateFuelFlow', () => {
+    it('handles missing previous fuel', () => {
+      assert.strictEqual(calculateFuelFlow(10, null, 1), 0);
+    });
+    it('handles non-positive dt', () => {
+      assert.strictEqual(calculateFuelFlow(10, 12, 0), 0);
+    });
+    it('computes fuel flow', () => {
+      assert.strictEqual(calculateFuelFlow(10, 12, 2), 1);
+    });
+  });
 
-(function testCalculateInstantConsumption() {
-  assert.strictEqual(
-    calculateInstantConsumption(0.002, 20),
-    0.002 / 20 * 100000,
-    'computes instant consumption'
-  );
-  assert.strictEqual(
-    calculateInstantConsumption(0.001, 0),
-    Infinity,
-    'handles zero speed'
-  );
-})();
+  describe('calculateInstantConsumption', () => {
+    it('computes instant consumption', () => {
+      assert.strictEqual(
+        calculateInstantConsumption(0.002, 20),
+        0.002 / 20 * 100000
+      );
+    });
+    it('handles zero speed', () => {
+      assert.strictEqual(
+        calculateInstantConsumption(0.001, 0),
+        Infinity
+      );
+    });
+  });
 
-(function testTrimQueue() {
-  const queue = [];
-  for (let i = 0; i < 10; i++) queue.push(i);
-  trimQueue(queue, 5);
-  assert.strictEqual(queue.length, 5, 'queue trimmed to max entries');
-  assert.deepStrictEqual(queue, [5,6,7,8,9], 'oldest entries removed');
-})();
+  describe('trimQueue', () => {
+    it('trims oldest entries to max size', () => {
+      const queue = [];
+      for (let i = 0; i < 10; i++) queue.push(i);
+      trimQueue(queue, 5);
+      assert.strictEqual(queue.length, 5);
+      assert.deepStrictEqual(queue, [5, 6, 7, 8, 9]);
+    });
+  });
 
-(function testCalculateRange() {
-  const EPS_SPEED = 0.005;
-  assert.strictEqual(calculateRange(10, 5, 1, EPS_SPEED), 2, 'finite range computed');
-  assert.strictEqual(calculateRange(10, 0, 1, EPS_SPEED), Infinity, 'infinite range when moving with zero consumption');
-  assert.strictEqual(calculateRange(10, 0, 0, EPS_SPEED), 0, 'zero range when stopped with zero consumption');
-})();
-
-console.log('All tests passed');
+  describe('calculateRange', () => {
+    const EPS_SPEED = 0.005;
+    it('computes finite range when consuming fuel', () => {
+      assert.strictEqual(calculateRange(10, 5, 1, EPS_SPEED), 2);
+    });
+    it('computes infinite range when moving without consumption', () => {
+      assert.strictEqual(calculateRange(10, 0, 1, EPS_SPEED), Infinity);
+    });
+    it('computes zero range when stopped without consumption', () => {
+      assert.strictEqual(calculateRange(10, 0, 0, EPS_SPEED), 0);
+    });
+  });
+});

--- a/tests/cumulative.test.js
+++ b/tests/cumulative.test.js
@@ -1,0 +1,30 @@
+const assert = require('node:assert');
+const { describe, it } = require('node:test');
+
+// Stub minimal angular object so the module can be required in Node.
+global.angular = { module: () => ({ directive: () => ({}) }) };
+
+const { calculateFuelFlow } = require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+
+describe('cumulative tracking', () => {
+  it('tracks cumulative fuel usage and distance', () => {
+    const fuelLevels = [50, 49.9, 49.7, 49.4];
+    const dt = 1; // seconds between updates
+    const speed = 10; // constant speed m/s
+
+    let prev = fuelLevels[0];
+    let totalFuel = 0;
+    let totalDistance = 0;
+
+    for (let i = 1; i < fuelLevels.length; i++) {
+      const curr = fuelLevels[i];
+      const flow = calculateFuelFlow(curr, prev, dt); // L/s
+      totalFuel += flow * dt;
+      totalDistance += speed * dt;
+      prev = curr;
+    }
+
+    assert.ok(Math.abs(totalFuel - 0.6) < 1e-9);
+    assert.strictEqual(totalDistance, 30);
+  });
+});


### PR DESCRIPTION
## Summary
- switch test script to `node --test` to avoid external dependencies
- refactor existing tests to use `node:test` and built-in assertions
- account for floating-point precision in cumulative tracking test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab99fd4a1483299f5d8d5d9db88f99