### PR TITLE
Add Node.js CI workflow to run npm tests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,21 @@
+name: Node.js CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run npm tests automatically on pushes and pull requests for Node 18 and 20

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aba1a25b9083299058b695a34aaaca