### PR TITLE
feat: persist overall consumption over entire trip

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -66,12 +66,12 @@ angular.module('beamng.apps')
 
       // --------- Overall persistence (NEW) ----------
       var OVERALL_KEY = 'okFuelEconomyOverall';
-      var MAX_ENTRIES = 2500; // pevný počet hodnot pro frontu
 
-      var overall = { queue: [], distance: 0 }; // fronta posledních průměrů + celková ujetá vzdálenost
+      // dlouhodobé ukládání průměrné spotřeby a ujeté vzdálenosti
+      var overall = { avg: 0, count: 0, distance: 0 };
       try {
           var saved = JSON.parse(localStorage.getItem(OVERALL_KEY));
-          if (saved && Array.isArray(saved.queue)) {
+          if (saved && typeof saved.avg === 'number' && typeof saved.count === 'number') {
               overall = saved;
           }
       } catch (e) { /* ignore */ }
@@ -96,7 +96,7 @@ angular.module('beamng.apps')
       // reset overall včetně vzdálenosti
       $scope.resetOverall = function () {
           $log.debug('<ok-fuel-economy> manual reset overall');
-          overall = { queue: [], distance: 0 };
+          overall = { avg: 0, count: 0, distance: 0 };
           saveOverall();
           $scope.data7 = UiUnits.buildString('consumptionRate', 0, 1);
           $scope.data6 = UiUnits.buildString('distance', 0, 1); // reset trip
@@ -166,20 +166,16 @@ angular.module('beamng.apps')
 
           if (speed_mps > EPS_SPEED) {
               shouldPush = true; // vozidlo jede → libovolný růst
-          } else {
-              if (throttle > 0.2) {
-                  shouldPush = true; // stojí, ale motor v zátěži → libovolný růst
-              } else {
-                  // stojí, motor volnoběh → jen pokud průměrná spotřeba neklesá
-                  if (avg_l_per_100km_ok <= overall.previousAvg) {
-                      shouldPush = true;
-                  }
-              }
+          } else if (throttle > 0.2) {
+              shouldPush = true; // stojí, ale motor v zátěži → libovolný růst
+          } else if (avg_l_per_100km_ok <= overall.previousAvg) {
+              // stojí, motor volnoběh → jen pokud průměrná spotřeba neklesá
+              shouldPush = true;
           }
 
           if (shouldPush && avg_l_per_100km_ok > 0) {
-              overall.queue.push(avg_l_per_100km_ok);
-              trimQueue(overall.queue, MAX_ENTRIES);
+              overall.avg = (overall.avg * overall.count + avg_l_per_100km_ok) / (overall.count + 1);
+              overall.count += 1;
 
               if (speed_mps > EPS_SPEED) {
                   overall.distance = (overall.distance || 0) + deltaDistance;
@@ -195,21 +191,7 @@ angular.module('beamng.apps')
               }
           }
 
-
-          // Overall median: počítat z libovolného počtu prvků
-          function median(arr) {
-              if (arr.length === 0) return 0;
-              const sorted = arr.slice().sort((a, b) => a - b);
-              const mid = Math.floor(sorted.length / 2);
-              if (sorted.length % 2 === 0) {
-                  return (sorted[mid - 1] + sorted[mid]) / 2;
-              } else {
-                  return sorted[mid];
-              }
-          }
-
-          var overall_median = median(overall.queue);
-          // ---------- Overall update (NEW) ----------
+          var overall_avg = overall.avg;
 
           // ---------- Average Consumption rules (prevent increasing while stopped) ----------
           var throttle = streams.electrics.throttle_input || 0;
@@ -239,9 +221,9 @@ angular.module('beamng.apps')
                          ? UiUnits.buildString('distance', rangeVal, 0)
                          : 'Infinity';
 
-          var rangeOverallMedianVal = calculateRange(currentFuel_l, overall_median, speed_mps, EPS_SPEED);
-          var rangeOverallMedianStr = Number.isFinite(rangeOverallMedianVal)
-                         ? UiUnits.buildString('distance', rangeOverallMedianVal, 0)
+          var rangeOverallVal = calculateRange(currentFuel_l, overall_avg, speed_mps, EPS_SPEED);
+          var rangeOverallStr = Number.isFinite(rangeOverallVal)
+                         ? UiUnits.buildString('distance', rangeOverallVal, 0)
                          : 'Infinity';
 
           $scope.data1 = UiUnits.buildString('distance', distance_m, 1);
@@ -252,9 +234,9 @@ angular.module('beamng.apps')
           $scope.data4 = rangeStr;
           $scope.data5 = instantStr;
           $scope.data6 = UiUnits.buildString('distance', trip_m, 1);
-          $scope.data7 = UiUnits.buildString('consumptionRate', overall_median, 1);
+          $scope.data7 = UiUnits.buildString('consumptionRate', overall_avg, 1);
           $scope.data8 = UiUnits.buildString('distance', overall.distance, 1);
-          $scope.data9 = rangeOverallMedianStr;
+          $scope.data9 = rangeOverallStr;
           $scope.vehicleNameStr = bngApi.engineLua("be:getPlayerVehicle(0)");
         });
       });


### PR DESCRIPTION
## Summary
- persist average consumption across the whole trip instead of keeping a capped queue
- update stored average incrementally and reuse it for range and display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abd7e1b0c08329976b19704e207dfb