### PR TITLE
Add style toggle for fuel economy app

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -1,140 +1,93 @@
 <div class="bngApp"
-     style="
-      width:100%; height:100%; overflow:auto; position:relative;
-      padding:4px; border-radius:10px; 
-      background-color:rgba(10,15,20,0.75); /* semi-transparent */
-      /* subtle neon grid */
-      background-image:
-        linear-gradient(rgba(0,200,255,0.05) 1px, transparent 1px),
-        linear-gradient(90deg, rgba(0,200,255,0.05) 1px, transparent 1px);
-      background-size:16px 16px, 16px 16px;
-      color:#aeeaff; 
-      font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      letter-spacing:0.3px;
-      box-shadow: inset 0 0 10px rgba(0,200,255,0.25);
-     " layout="column">
+     ng-init="useCustomStyles=true"
+     ng-attr-style="{{ 'width:100%; height:100%; overflow:auto; position:relative;' + (useCustomStyles ? ' padding:4px; border-radius:10px; background-color:rgba(10,15,20,0.75); background-image:linear-gradient(rgba(0,200,255,0.05) 1px, transparent 1px), linear-gradient(90deg, rgba(0,200,255,0.05) 1px, transparent 1px), url('app.png'); background-size:16px 16px,16px 16px,cover; background-repeat:repeat, repeat, no-repeat; color:#aeeaff; font-family:"Segoe UI", Tahoma, Geneva, Verdana, sans-serif; letter-spacing:0.3px; box-shadow: inset 0 0 10px rgba(0,200,255,0.25);' : '') }}"
+     layout="column">
 
-  <strong style="
-      display:block; margin:2px 0 6px;
-      font-size:1em; font-weight:600;
-      color:#3fd6ff; text-shadow:0 0 5px rgba(0,255,255,0.6);
-    ">
+  <strong ng-attr-style="{{ useCustomStyles ? 'display:block; margin:2px 0 6px; font-size:1em; font-weight:600; color:#3fd6ff; text-shadow:0 0 5px rgba(0,255,255,0.6);' : '' }}">
     Fuel Economy: {{ vehicleNameStr }}
   </strong>
 
-  <table style="width:100%; border-collapse:collapse; font-size:0.85em;">
+  <table ng-attr-style="{{ useCustomStyles ? 'width:100%; border-collapse:collapse; font-size:0.85em;' : '' }}">
     <tr>
-      <td style="padding:3px 2px; width:38%;
-                 color:#69e0ff; font-weight:500;
-                 text-shadow:0 0 3px rgba(0,255,255,0.4);
-                 border-bottom:1px solid rgba(0,180,255,0.10);">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; width:38%; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         Traveled distance:
       </td>
-      <td style="padding:3px 2px; color:#ccefff;
-                 border-bottom:1px solid rgba(0,180,255,0.10);">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         Measured: {{ data1 }} | From ECU: {{ data6 }}
       </td>
     </tr>
 
     <tr>
-      <td style="padding:3px 2px; width:38%;
-                 color:#69e0ff; font-weight:500;
-                 text-shadow:0 0 3px rgba(0,255,255,0.4);
-                 border-bottom:1px solid rgba(0,180,255,0.10);">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; width:38%; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         Fuel (used / left / capacity):
       </td>
-      <td style="padding:3px 2px; color:#ccefff;
-                 border-bottom:1px solid rgba(0,180,255,0.10);">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         {{ data2 }}
       </td>
     </tr>
 
     <tr>
-      <td style="padding:3px 2px; color:#69e0ff; font-weight:500;
-                 text-shadow:0 0 3px rgba(0,255,255,0.4);
-                 border-bottom:1px solid rgba(0,180,255,0.10);">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         Average consumption:
       </td>
-      <td style="padding:3px 2px; color:#ccefff;
-                 border-bottom:1px solid rgba(0,180,255,0.10);">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         {{ data3 }}
       </td>
     </tr>
 
     <tr>
-      <td style="padding:3px 2px; color:#69e0ff; font-weight:500;
-                 text-shadow:0 0 3px rgba(0,255,255,0.4);
-                 border-bottom:1px solid rgba(0,180,255,0.10);">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         Instant consumption:
       </td>
-      <td style="padding:3px 2px; color:#ccefff;
-                 border-bottom:1px solid rgba(0,180,255,0.10);">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         {{ data5 }}
       </td>
     </tr>
 
     <tr>
-      <td style="padding:3px 2px; color:#69e0ff; font-weight:500;
-                 text-shadow:0 0 3px rgba(0,255,255,0.4);
-                 border-bottom:1px solid rgba(0,180,255,0.10);">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         Range:
       </td>
-      <td style="padding:3px 2px; color:#ccefff;
-                 border-bottom:1px solid rgba(0,180,255,0.10);">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         {{ data4 }}
       </td>
     </tr>
 
     <tr>
-      <td style="padding:3px 2px; color:#69e0ff; font-weight:500;
-                 text-shadow:0 0 3px rgba(0,255,255,0.4);
-                 border-bottom:1px solid rgba(0,180,255,0.10);">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         Trip average consumption:
       </td>
-      <td style="padding:3px 2px; color:#ccefff;
-                 border-bottom:1px solid rgba(0,180,255,0.10);">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         {{ data7 }}
       </td>
     </tr>
 
     <tr>
-      <td style="padding:3px 2px; color:#69e0ff; font-weight:500;
-                 text-shadow:0 0 3px rgba(0,255,255,0.4);
-                 border-bottom:1px solid rgba(0,180,255,0.10);">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         Trip distance:
       </td>
-      <td style="padding:3px 2px; color:#ccefff;
-                 border-bottom:1px solid rgba(0,180,255,0.10);">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         {{ data8 }}
       </td>
     </tr>
 
     <tr>
-      <td style="padding:3px 2px; color:#69e0ff; font-weight:500;
-                 text-shadow:0 0 3px rgba(0,255,255,0.4);
-                 border-bottom:1px solid rgba(0,180,255,0.10);">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         Trip range:
       </td>
-      <td style="padding:3px 2px; color:#ccefff;
-                 border-bottom:1px solid rgba(0,180,255,0.10);">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         {{ data9 }}
       </td>
     </tr>
 
     <tr>
-      <td style="padding:3px 2px; color:#69e0ff; font-weight:500;
-                 text-shadow:0 0 3px rgba(0,255,255,0.4);
-                 border-bottom:1px solid rgba(0,180,255,0.10);">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         Trip reset:
       </td>
-      <td style="padding:3px 2px; color:#ccefff;
-                 border-bottom:1px solid rgba(0,180,255,0.10);">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         <span class="material-icons"
               ng-click="resetOverall($event)"
-              style="
-                cursor:pointer; margin-left:6px;
-                color:#5fdcff; text-shadow:0 0 5px rgba(0,255,255,0.6);
-              ">
+              ng-attr-style="{{ 'cursor:pointer; margin-left:6px;' + (useCustomStyles ? ' color:#5fdcff; text-shadow:0 0 5px rgba(0,255,255,0.6);' : '') }}">
           delete
         </span>
       </td>
@@ -144,11 +97,13 @@
   <!-- Reset icon (global) -->
   <span class="material-icons"
         ng-click="reset($event)"
-        style="
-          position:absolute; top:2px; right:4px; cursor:pointer;
-          font-size:18px; color:#5fdcff;
-          text-shadow:0 0 5px rgba(0,255,255,0.6);
-        ">
+        ng-attr-style="{{ 'position:absolute; top:2px; right:4px; cursor:pointer; font-size:18px;' + (useCustomStyles ? ' color:#5fdcff; text-shadow:0 0 5px rgba(0,255,255,0.6);' : '') }}">
     autorenew
+  </span>
+  <!-- Style toggle icon -->
+  <span class="material-icons"
+        ng-click="useCustomStyles=!useCustomStyles"
+        ng-attr-style="{{ 'position:absolute; top:24px; right:4px; cursor:pointer; font-size:18px;' + (useCustomStyles ? ' color:#5fdcff; text-shadow:0 0 5px rgba(0,255,255,0.6);' : '') }}">
+    palette
   </span>
 </div>

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1,0 +1,128 @@
+const assert = require('node:assert');
+const { describe, it } = require('node:test');
+const fs = require('fs');
+const path = require('path');
+
+const htmlPath = path.join(__dirname, '..', 'okFuelEconomy', 'ui', 'modules', 'apps', 'okFuelEconomy', 'app.html');
+const html = fs.readFileSync(htmlPath, 'utf8');
+
+function extractAttr(source, startMarker) {
+  const start = source.indexOf(startMarker);
+  let i = start + startMarker.length;
+  let value = '';
+  let inSingle = false;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === '\\') {
+      value += ch;
+      i++;
+      if (i < source.length) value += source[i];
+    } else if (ch === "'") {
+      inSingle = !inSingle;
+      value += ch;
+    } else if (ch === '"' && !inSingle) {
+      break;
+    } else {
+      value += ch;
+    }
+    i++;
+  }
+  return value;
+}
+
+function getNgAttrStyle(elementMarker) {
+  const elemIdx = html.indexOf(elementMarker);
+  const slice = html.slice(elemIdx);
+  return extractAttr(slice, 'ng-attr-style="');
+}
+
+function parseStyle(expr) {
+  const prefix = "{{ '";
+  const delim = "' + (useCustomStyles ? '";
+  const suffix = "' : '') }}";
+  const base = expr.slice(prefix.length, expr.indexOf(delim));
+  const custom = expr.slice(expr.indexOf(delim) + delim.length, expr.lastIndexOf(suffix));
+  return { base, custom };
+}
+
+describe('UI template styling', () => {
+  it('toggles custom styling correctly', () => {
+    const attr = getNgAttrStyle('<div class="bngApp"');
+    const { base, custom } = parseStyle(attr);
+    const styleTrue = base + custom;
+
+    assert.ok(base.includes('position:relative;'));
+    assert.ok(!base.includes('background-color'));
+    assert.ok(styleTrue.includes('background-color:rgba(10,15,20,0.75);'));
+    assert.ok(styleTrue.includes("url('app.png')"));
+  });
+
+  it('positions reset and style toggle icons consistently', () => {
+    const resetAttr = getNgAttrStyle('ng-click="reset($event)"');
+    const toggleAttr = getNgAttrStyle('ng-click="useCustomStyles=!useCustomStyles"');
+    const r = parseStyle(resetAttr);
+    const t = parseStyle(toggleAttr);
+
+    assert.ok(r.base.includes('position:absolute; top:2px; right:4px;'));
+    assert.ok(t.base.includes('position:absolute; top:24px; right:4px;'));
+    assert.ok(r.base.includes('cursor:pointer;'));
+    assert.ok(t.base.includes('cursor:pointer;'));
+    assert.ok(r.base.includes('font-size:18px;'));
+    assert.ok(t.base.includes('font-size:18px;'));
+
+    assert.ok(r.custom.includes('color:#5fdcff;'));
+    assert.ok(t.custom.includes('color:#5fdcff;'));
+  });
+
+  it('preserves neon background and typography when custom styles are enabled', () => {
+    assert.ok(html.includes('background-image:linear-gradient'));
+    assert.ok(html.includes('border-radius:10px;'));
+    assert.ok(html.includes('color:#aeeaff;'));
+    assert.ok(html.includes('font-family:"Segoe UI", Tahoma, Geneva, Verdana, sans-serif;'));
+    assert.ok(html.includes('box-shadow: inset 0 0 10px rgba(0,200,255,0.25);'));
+  });
+
+  it('provides all data placeholders and icons', () => {
+    for (let i = 1; i <= 9; i++) {
+      assert.ok(html.includes(`{{ data${i} }}`), `missing data${i}`);
+    }
+    assert.ok(html.includes('{{ vehicleNameStr }}'));
+    assert.ok(html.includes('ng-click="reset($event)"'));
+    assert.ok(html.includes('ng-click="useCustomStyles=!useCustomStyles"'));
+    assert.ok(html.includes('autorenew'));
+    assert.ok(html.includes('palette'));
+  });
+});
+
+describe('controller integration', () => {
+  it('populates data fields from stream updates', () => {
+    let directiveDef;
+    global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };
+    global.StreamsManager = { add: () => {}, remove: () => {} };
+    global.UiUnits = { buildString: (type, val, prec) => (val.toFixed ? val.toFixed(prec) : String(val)) };
+    global.bngApi = { engineLua: () => '' };
+    global.localStorage = { getItem: () => null, setItem: () => {} };
+    global.performance = { now: (() => { let t = 0; return () => { t += 1000; return t; }; })() };
+
+    delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
+    require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+    const controllerFn = directiveDef.controller[2];
+    const $scope = {
+      $on: (name, cb) => { $scope['on_' + name] = cb; },
+      $evalAsync: fn => fn()
+    };
+    controllerFn({ debug: () => {} }, $scope);
+
+    const streams = {
+      engineInfo: Array(15).fill(0),
+      electrics: { wheelspeed: 10, trip: 5, throttle_input: 0 }
+    };
+    streams.engineInfo[11] = 50;
+
+    $scope.on_streamsUpdate(null, streams);
+
+    for (let i = 1; i <= 9; i++) {
+      assert.notStrictEqual($scope['data' + i], '', `data${i} empty`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- allow users to toggle custom styling on the fuel economy app
- replace button with palette icon styled like the global reset icon
- keep reset and style toggle icons fixed in place even when custom styling is disabled
- restore original neon grid background and icon defaults when custom styles are active
- ensure custom app background image sits behind grid overlay for intended look
- add regression tests for style toggling, icon placement, background design, and data field updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abd98eaad083298d0a01c18a91dcbd