### PR TITLE
feat: add dynamic tests badge

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 permissions:
-  contents: read
+  contents: write
   checks: write
   pull-requests: write
 
@@ -52,3 +52,9 @@ jobs:
           path: reports/**/junit.xml
           reporter: java-junit
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate test badge
+        run: node scripts/generate-badge.js reports/**/junit.xml
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update test badge"
+          file_pattern: tests-badge.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BeamNG Fuel Economy UI App
 
-[![Node.js CI](https://github.com/KRtkovo-eu-AI/BeamNG_Fuel_Economy_mod/actions/workflows/node.js.yml/badge.svg)](https://github.com/KRtkovo-eu-AI/BeamNG_Fuel_Economy_mod/actions/workflows/node.js.yml) [![Tests](https://img.shields.io/badge/tests-46%20passed-brightgreen)](https://github.com/KRtkovo-eu-AI/BeamNG_Fuel_Economy_mod/actions/workflows/node.js.yml) [![Release](https://img.shields.io/github/v/tag/KRtkovo-eu-AI/BeamNG_Fuel_Economy_mod?sort=semver&label=version)](https://github.com/KRtkovo-eu-AI/BeamNG_Fuel_Economy_mod/tags)
+[![Node.js CI](https://github.com/KRtkovo-eu-AI/BeamNG_Fuel_Economy_mod/actions/workflows/node.js.yml/badge.svg)](https://github.com/KRtkovo-eu-AI/BeamNG_Fuel_Economy_mod/actions/workflows/node.js.yml) [![Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/KRtkovo-eu-AI/BeamNG_Fuel_Economy_mod/main/tests-badge.json)](https://github.com/KRtkovo-eu-AI/BeamNG_Fuel_Economy_mod/actions/workflows/node.js.yml) [![Release](https://img.shields.io/github/v/tag/KRtkovo-eu-AI/BeamNG_Fuel_Economy_mod?sort=semver&label=version)](https://github.com/KRtkovo-eu-AI/BeamNG_Fuel_Economy_mod/tags)
 
 ![Fuel Economy](https://raw.githubusercontent.com/KRtkovo-eu-AI/BeamNG_Fuel_Economy_mod/refs/heads/main/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.png "Fuel Economy")
 

--- a/scripts/generate-badge.js
+++ b/scripts/generate-badge.js
@@ -1,0 +1,30 @@
+import fs from 'node:fs';
+
+const files = process.argv.slice(2);
+let total = 0;
+let failed = 0;
+let skipped = 0;
+
+for (const file of files) {
+  const xml = fs.readFileSync(file, 'utf8');
+  const cases = [...xml.matchAll(/<testcase\b[^>]*>/g)].length;
+  const failures = [...xml.matchAll(/<failure\b[^>]*>/g)].length;
+  const errors = [...xml.matchAll(/<error\b[^>]*>/g)].length;
+  const skips = [...xml.matchAll(/<skipped\b[^>]*>/g)].length;
+  total += cases;
+  failed += failures + errors;
+  skipped += skips;
+}
+
+const passed = total - failed - skipped;
+const color = failed > 0 ? 'red' : 'brightgreen';
+let message = `${passed} passed`;
+if (failed > 0 || skipped > 0) {
+  message += `, ${failed} failed`;
+  if (skipped > 0) {
+    message += `, ${skipped} skipped`;
+  }
+}
+
+const badge = { schemaVersion: 1, label: 'tests', message, color };
+fs.writeFileSync('tests-badge.json', JSON.stringify(badge));

--- a/tests-badge.json
+++ b/tests-badge.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"tests","message":"62 passed","color":"brightgreen"}


### PR DESCRIPTION
## Summary
- add script to generate Shields.io badge from JUnit XML
- commit test badge from CI and show it in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abfb67bfc08329bc8cc14152afa577