### PR TITLE
Add trip average consumption history graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository contains a UI mod for BeamNG.drive that displays fuel economy in
 - Estimated range based on current and long-term consumption.
 - Long-term consumption overview with reset option.
 - Trip statistics showing average consumption, distance and range, with reset control.
+- History graphs for average and trip average fuel consumption with toggleable visibility and custom style support.
 - Hide or show heading and individual data points through an in-app settings dialog that remembers user choices.
 - Switch between the default BeamNG style and a custom neon-themed look.
 

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -71,6 +71,17 @@
       </td>
     </tr>
 
+    <tr ng-if="visible.tripGraph">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
+        Trip average history:
+      </td>
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
+        <svg viewBox="0 0 100 40" preserveAspectRatio="none" ng-attr-style="{{ 'width:100%; height:40px;' + (useCustomStyles ? ' background:rgba(0,200,255,0.05);' : '') }}">
+          <polyline ng-attr-points="{{ tripAvgHistory }}" ng-attr-style="{{ 'fill:none;stroke:' + (useCustomStyles ? '#5fdcff' : 'currentColor') + ';stroke-width:1;' }}"></polyline>
+        </svg>
+      </td>
+    </tr>
+
     <tr ng-if="visible.tripDistance">
       <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         Trip distance:
@@ -136,6 +147,7 @@
     <label><input type="checkbox" ng-model="visible.instantL100km"> Instant L/100km</label><br>
     <label><input type="checkbox" ng-model="visible.range"> Range</label><br>
     <label><input type="checkbox" ng-model="visible.tripAvg"> Trip average consumption</label><br>
+    <label><input type="checkbox" ng-model="visible.tripGraph"> Trip average history</label><br>
     <label><input type="checkbox" ng-model="visible.tripDistance"> Trip distance</label><br>
     <label><input type="checkbox" ng-model="visible.tripRange"> Trip range</label><br>
     <label><input type="checkbox" ng-model="visible.tripReset"> Trip reset</label><br>

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -42,6 +42,17 @@
       </td>
     </tr>
 
+    <tr ng-if="visible.avgGraph">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
+        Average history:
+      </td>
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
+        <svg viewBox="0 0 100 40" preserveAspectRatio="none" ng-attr-style="{{ 'width:100%; height:40px;' + (useCustomStyles ? ' background:rgba(0,200,255,0.05);' : '') }}">
+          <polyline ng-attr-points="{{ avgHistory }}" ng-attr-style="{{ 'fill:none;stroke:' + (useCustomStyles ? '#5fdcff' : 'currentColor') + ';stroke-width:1;' }}"></polyline>
+        </svg>
+      </td>
+    </tr>
+
     <tr ng-if="visible.instantLph || visible.instantL100km">
       <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         Instant consumption:
@@ -143,6 +154,7 @@
     <label><input type="checkbox" ng-model="visible.fuelLeft"> Fuel left</label><br>
     <label><input type="checkbox" ng-model="visible.fuelCap"> Fuel capacity</label><br>
     <label><input type="checkbox" ng-model="visible.avg"> Average consumption</label><br>
+    <label><input type="checkbox" ng-model="visible.avgGraph"> Average history</label><br>
     <label><input type="checkbox" ng-model="visible.instantLph"> Instant L/h</label><br>
     <label><input type="checkbox" ng-model="visible.instantL100km"> Instant L/100km</label><br>
     <label><input type="checkbox" ng-model="visible.range"> Range</label><br>

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -54,13 +54,27 @@ function calculateRange(currentFuel_l, avg_l_per_100km_ok, speed_mps, EPS_SPEED)
   return speed_mps > EPS_SPEED ? Infinity : 0;
 }
 
+function buildQueueGraphPoints(queue, width, height) {
+  if (!Array.isArray(queue) || queue.length < 2) return '';
+  var max = Math.max.apply(null, queue);
+  if (max <= 0) return '';
+  return queue
+    .map(function (val, i) {
+      var x = (i / (queue.length - 1)) * width;
+      var y = height - (val / max) * height;
+      return x.toFixed(1) + ',' + y.toFixed(1);
+    })
+    .join(' ');
+}
+
 if (typeof module !== 'undefined') {
   module.exports = {
     calculateFuelFlow,
     calculateInstantConsumption,
     smoothFuelFlow,
     trimQueue,
-    calculateRange
+    calculateRange,
+    buildQueueGraphPoints
   };
 }
 
@@ -94,6 +108,7 @@ angular.module('beamng.apps')
         instantL100km: true,
         range: true,
         tripAvg: true,
+        tripGraph: true,
         tripDistance: true,
         tripRange: true,
         tripReset: true
@@ -126,6 +141,7 @@ angular.module('beamng.apps')
       $scope.instantLph = '';
       $scope.instantL100km = '';
       $scope.data7 = ''; // overall average
+      $scope.tripAvgHistory = '';
 
       var distance_m = 0;
       var lastTime_ms = performance.now();
@@ -178,6 +194,7 @@ angular.module('beamng.apps')
           saveOverall();
           $scope.data7 = UiUnits.buildString('consumptionRate', 0, 1);
           $scope.data6 = UiUnits.buildString('distance', 0, 1); // reset trip
+          $scope.tripAvgHistory = '';
       };
 
       $scope.$on('VehicleFocusChanged', function () {
@@ -309,6 +326,7 @@ angular.module('beamng.apps')
           }
 
           var overall_median = median(overall.queue);
+          $scope.tripAvgHistory = buildQueueGraphPoints(overall.queue, 100, 40);
           // ---------- Overall update (NEW) ----------
 
           // ---------- Average Consumption rules (prevent increasing while stopped) ----------

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -104,6 +104,7 @@ angular.module('beamng.apps')
         fuelLeft: true,
         fuelCap: true,
         avg: true,
+        avgGraph: true,
         instantLph: true,
         instantL100km: true,
         range: true,
@@ -142,6 +143,7 @@ angular.module('beamng.apps')
       $scope.instantL100km = '';
       $scope.data7 = ''; // overall average
       $scope.tripAvgHistory = '';
+      $scope.avgHistory = '';
 
       var distance_m = 0;
       var lastTime_ms = performance.now();
@@ -174,6 +176,22 @@ angular.module('beamng.apps')
           try { localStorage.setItem(OVERALL_KEY, JSON.stringify(overall)); } catch (e) { /* ignore */ }
       }
 
+      // --------- Average history persistence (NEW) ----------
+      var AVG_KEY = 'okFuelEconomyAvgHistory';
+      var AVG_MAX_ENTRIES = 1000;
+
+      var avgHistory = { queue: [] };
+      try {
+          var savedAvg = JSON.parse(localStorage.getItem(AVG_KEY));
+          if (savedAvg && Array.isArray(savedAvg.queue)) {
+              avgHistory = savedAvg;
+          }
+      } catch (e) { /* ignore */ }
+
+      function saveAvgHistory() {
+          try { localStorage.setItem(AVG_KEY, JSON.stringify(avgHistory)); } catch (e) { /* ignore */ }
+      }
+
       function hardReset() {
         distance_m = 0;
         startFuel_l = null;
@@ -192,9 +210,12 @@ angular.module('beamng.apps')
           $log.debug('<ok-fuel-economy> manual reset overall');
           overall = { queue: [], distance: 0 };
           saveOverall();
+          avgHistory = { queue: [] };
+          saveAvgHistory();
           $scope.data7 = UiUnits.buildString('consumptionRate', 0, 1);
           $scope.data6 = UiUnits.buildString('distance', 0, 1); // reset trip
           $scope.tripAvgHistory = '';
+          $scope.avgHistory = '';
       };
 
       $scope.$on('VehicleFocusChanged', function () {
@@ -350,6 +371,16 @@ angular.module('beamng.apps')
               avg_l_per_100km_ok = overall.previousAvgTrip;
           }
 
+          if (avg_l_per_100km_ok > 0) {
+              avgHistory.queue.push(avg_l_per_100km_ok);
+              trimQueue(avgHistory.queue, AVG_MAX_ENTRIES);
+              $scope.avgHistory = buildQueueGraphPoints(avgHistory.queue, 100, 40);
+              if (!avgHistory.lastSaveTime) avgHistory.lastSaveTime = 0;
+              if (now_ms - avgHistory.lastSaveTime >= 100) {
+                  saveAvgHistory();
+                  avgHistory.lastSaveTime = now_ms;
+              }
+          }
 
           var rangeVal = calculateRange(currentFuel_l, avg_l_per_100km_ok, speed_mps, EPS_SPEED);
           var rangeStr = Number.isFinite(rangeVal)

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
@@ -1,7 +1,7 @@
 {
   "name" : "Fuel Economy",
   "author": "KRtekTM",
-  "version": "1.0.0.4",
+  "version": "1.0.0.5",
   "description": "Fuel Economy - Average Fuel Consumption",
   "directive": "okFuelEconomy",
   "domElement": "<ok-fuel-economy></ok-fuel-economy>",

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -9,7 +9,8 @@ const {
   calculateInstantConsumption,
   smoothFuelFlow,
   trimQueue,
-  calculateRange
+  calculateRange,
+  buildQueueGraphPoints
 } = require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
 
 describe('app.js utility functions', () => {
@@ -120,6 +121,19 @@ describe('app.js utility functions', () => {
     });
     it('treats negative avg as no consumption while stopped', () => {
       assert.strictEqual(calculateRange(10, -5, 0, EPS_SPEED), 0);
+    });
+  });
+
+  describe('buildQueueGraphPoints', () => {
+    it('returns empty string for short queues', () => {
+      assert.strictEqual(buildQueueGraphPoints([1], 100, 40), '');
+    });
+    it('scales values to width and height', () => {
+      const pts = buildQueueGraphPoints([0, 100], 100, 40);
+      assert.strictEqual(pts, '0.0,40.0 100.0,0.0');
+    });
+    it('handles zero max values', () => {
+      assert.strictEqual(buildQueueGraphPoints([0, 0], 100, 40), '');
     });
   });
 });

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -132,6 +132,10 @@ describe('app.js utility functions', () => {
       const pts = buildQueueGraphPoints([0, 100], 100, 40);
       assert.strictEqual(pts, '0.0,40.0 100.0,0.0');
     });
+    it('handles intermediate values', () => {
+      const pts = buildQueueGraphPoints([0, 50, 100], 100, 40);
+      assert.strictEqual(pts, '0.0,40.0 50.0,20.0 100.0,0.0');
+    });
     it('handles zero max values', () => {
       assert.strictEqual(buildQueueGraphPoints([0, 0], 100, 40), '');
     });


### PR DESCRIPTION
## Summary
- add utility to build SVG polyline from trip average queue
- display history graph of trip average consumption with toggleable visibility
- cover graph point generator with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acce810f548329b087270f00c1fda0