### PR TITLE
Add instant consumption history graph

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -64,6 +64,17 @@
       </td>
     </tr>
 
+    <tr ng-if="visible.instantGraph">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
+        Instant L/h history:
+      </td>
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
+        <svg viewBox="0 0 100 40" preserveAspectRatio="none" ng-attr-style="{{ 'width:100%; height:40px;' + (useCustomStyles ? ' background:rgba(0,200,255,0.05);' : '') }}">
+          <polyline ng-attr-points="{{ instantHistory }}" ng-attr-style="{{ 'fill:none;stroke:' + (useCustomStyles ? '#5fdcff' : 'currentColor') + ';stroke-width:1;' }}"></polyline>
+        </svg>
+      </td>
+    </tr>
+
     <tr ng-if="visible.range">
       <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         Range:
@@ -157,6 +168,7 @@
     <label><input type="checkbox" ng-model="visible.avgGraph"> Average history</label><br>
     <label><input type="checkbox" ng-model="visible.instantLph"> Instant L/h</label><br>
     <label><input type="checkbox" ng-model="visible.instantL100km"> Instant L/100km</label><br>
+    <label><input type="checkbox" ng-model="visible.instantGraph"> Instant history</label><br>
     <label><input type="checkbox" ng-model="visible.range"> Range</label><br>
     <label><input type="checkbox" ng-model="visible.tripAvg"> Trip average consumption</label><br>
     <label><input type="checkbox" ng-model="visible.tripGraph"> Trip average history</label><br>

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
@@ -1,7 +1,7 @@
 {
   "name" : "Fuel Economy",
   "author": "KRtekTM",
-  "version": "1.0.0.5",
+  "version": "1.0.0.6",
   "description": "Fuel Economy - Average Fuel Consumption",
   "directive": "okFuelEconomy",
   "domElement": "<ok-fuel-economy></ok-fuel-economy>",

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -86,7 +86,7 @@ describe('UI template styling', () => {
   });
 
   it('provides all data placeholders and icons', () => {
-    const placeholders = ['data1','fuelUsed','fuelLeft','fuelCap','data3','data4','instantLph','instantL100km','data6','data7','data8','data9'];
+    const placeholders = ['data1','fuelUsed','fuelLeft','fuelCap','data3','data4','instantLph','instantL100km','instantHistory','data6','data7','data8','data9'];
     placeholders.forEach(p => {
       assert.ok(html.includes(`{{ ${p} }}`), `missing ${p}`);
     });
@@ -106,7 +106,8 @@ describe('UI template styling', () => {
     assert.ok(html.includes('ng-if="visible.distanceMeasured || visible.distanceEcu"'));
     assert.ok(html.includes('ng-if="visible.fuelUsed || visible.fuelLeft || visible.fuelCap"'));
     assert.ok(html.includes('ng-if="visible.instantLph || visible.instantL100km"'));
-    const toggles = ['visible.heading','visible.distanceMeasured','visible.distanceEcu','visible.fuelUsed','visible.fuelLeft','visible.fuelCap','visible.instantLph','visible.instantL100km'];
+    assert.ok(html.includes('ng-if="visible.instantGraph"'));
+    const toggles = ['visible.heading','visible.distanceMeasured','visible.distanceEcu','visible.fuelUsed','visible.fuelLeft','visible.fuelCap','visible.instantLph','visible.instantL100km','visible.instantGraph'];
     toggles.forEach(t => {
       assert.ok(html.includes(`ng-model="${t}"`), `missing toggle ${t}`);
     });
@@ -134,14 +135,16 @@ describe('controller integration', () => {
 
     const streams = {
       engineInfo: Array(15).fill(0),
-      electrics: { wheelspeed: 10, trip: 5, throttle_input: 0 }
+      electrics: { wheelspeed: 10, trip: 5, throttle_input: 0.5, rpmTacho: 1000 }
     };
     streams.engineInfo[11] = 50;
     streams.engineInfo[12] = 60;
 
     $scope.on_streamsUpdate(null, streams);
+    streams.engineInfo[11] = 49.9;
+    $scope.on_streamsUpdate(null, streams);
 
-    const fields = ['data1','fuelUsed','fuelLeft','fuelCap','data3','data4','instantLph','instantL100km','data6','data7','data8','data9'];
+    const fields = ['data1','fuelUsed','fuelLeft','fuelCap','data3','data4','instantLph','instantL100km','instantHistory','data6','data7','data8','data9'];
     fields.forEach(f => {
       assert.notStrictEqual($scope[f], '', `${f} empty`);
     });
@@ -211,6 +214,7 @@ describe('controller integration', () => {
 
     assert.strictEqual($scope.tripAvgHistory, '');
     assert.strictEqual($scope.avgHistory, '');
+    assert.strictEqual($scope.instantHistory, '');
   });
 
   it('ignores unrealistic consumption spikes while stationary', () => {
@@ -288,17 +292,20 @@ describe('visibility settings persistence', () => {
     $scope.visible.heading = false;
     $scope.visible.fuelLeft = false;
     $scope.visible.instantLph = false;
+    $scope.visible.instantGraph = false;
     $scope.saveSettings();
 
     assert.ok(store.okFuelEconomyVisible.includes('"heading":false'));
     assert.ok(store.okFuelEconomyVisible.includes('"fuelLeft":false'));
     assert.ok(store.okFuelEconomyVisible.includes('"instantLph":false'));
+    assert.ok(store.okFuelEconomyVisible.includes('"instantGraph":false'));
 
     const $scope2 = { $on: () => {} };
     controllerFn({ debug: () => {} }, $scope2);
     assert.equal($scope2.visible.heading, false);
     assert.equal($scope2.visible.fuelLeft, false);
     assert.equal($scope2.visible.instantLph, false);
+    assert.equal($scope2.visible.instantGraph, false);
     assert.equal($scope2.visible.fuelUsed, true);
   });
 });


### PR DESCRIPTION
## Summary
- add persistent instant L/h history queue with 1000-entry limit
- render instant consumption history graph with visibility toggle
- extend tests to cover instant history behavior and persistence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acf0cd8d8483299c7c3aca82488848