### PR TITLE
Reset instant consumption when engine stops

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -280,6 +280,9 @@ angular.module('beamng.apps')
           var throttle = streams.electrics.throttle_input || 0;
           var rpm = streams.electrics.rpmTacho || 0;
           var engineRunning = rpm > 0;
+          if (!engineRunning) {
+            idleFuelFlow_lps = 0;
+          }
 
           if (!Number.isFinite(currentFuel_l) || !Number.isFinite(capacity_l)) return;
 
@@ -326,12 +329,19 @@ angular.module('beamng.apps')
             idleFuelFlow_lps,
             EPS_SPEED
           );
-          lastFuelFlow_lps = fuelFlow_lps;
+          if (!engineRunning) {
+            fuelFlow_lps = 0;
+            lastFuelFlow_lps = 0;
+          } else {
+            lastFuelFlow_lps = fuelFlow_lps;
+          }
           previousFuel_l = currentFuel_l;
           lastThrottle = throttle;
 
           var inst_l_per_h = fuelFlow_lps * 3600;
-          var inst_l_per_100km = calculateInstantConsumption(fuelFlow_lps, speed_mps);
+          var inst_l_per_100km = engineRunning
+            ? calculateInstantConsumption(fuelFlow_lps, speed_mps)
+            : 0;
           if (now_ms - lastInstantUpdate_ms >= INSTANT_UPDATE_INTERVAL) {
             $scope.instantLph = inst_l_per_h.toFixed(1) + ' L/h';
             $scope.instantL100km = Number.isFinite(inst_l_per_100km)

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
@@ -1,7 +1,7 @@
 {
   "name" : "Fuel Economy",
   "author": "KRtekTM",
-  "version": "1.0.0.6",
+  "version": "1.0.0.7",
   "description": "Fuel Economy - Average Fuel Consumption",
   "directive": "okFuelEconomy",
   "domElement": "<ok-fuel-economy></ok-fuel-economy>",

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -184,6 +184,44 @@ describe('controller integration', () => {
     assert.notStrictEqual($scope.instantLph, first);
   });
 
+  it('resets instant consumption when engine stops', () => {
+    let directiveDef;
+    global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };
+    global.StreamsManager = { add: () => {}, remove: () => {} };
+    global.UiUnits = { buildString: () => '' };
+    global.bngApi = { engineLua: () => '' };
+    global.localStorage = { getItem: () => null, setItem: () => {} };
+    let now = 0;
+    global.performance = { now: () => now };
+
+    delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
+    require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+    const controllerFn = directiveDef.controller[2];
+    const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
+    controllerFn({ debug: () => {} }, $scope);
+
+    const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 10, airspeed: 10, throttle_input: 0.5, rpmTacho: 1000, trip: 0 } };
+    streams.engineInfo[11] = 50;
+    streams.engineInfo[12] = 60;
+
+    now = 0;
+    $scope.on_streamsUpdate(null, streams);
+    now = 300;
+    streams.engineInfo[11] = 49.99;
+    $scope.on_streamsUpdate(null, streams);
+    assert.notStrictEqual($scope.instantLph, '0.0 L/h');
+
+    streams.electrics.rpmTacho = 0;
+    streams.electrics.throttle_input = 0;
+    streams.electrics.wheelspeed = 0;
+    streams.electrics.airspeed = 0;
+    now = 600;
+    $scope.on_streamsUpdate(null, streams);
+
+    assert.strictEqual($scope.instantLph, '0.0 L/h');
+    assert.strictEqual($scope.instantL100km, '0.0 L/100km');
+  });
+
   it('skips history updates when engine is off', () => {
     let directiveDef;
     global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };


### PR DESCRIPTION
## Summary
- reset idle fuel flow and smoothed flow when the engine is not running so instant consumption reads zero
- test that instant consumption drops to 0 L/h and 0 L/100km after engine shutdown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acf97d3bb883299c1f85681354a9f3