### PR TITLE
Add km/L fuel consumption display

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -33,12 +33,14 @@
       </td>
     </tr>
 
-    <tr ng-if="visible.avg">
+    <tr ng-if="visible.avgL100km || visible.avgKmL">
       <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         Average consumption:
       </td>
       <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
-        {{ data3 }}
+        <span ng-if="visible.avgL100km">{{ avgL100km }}</span>
+        <span ng-if="visible.avgL100km && visible.avgKmL"> | </span>
+        <span ng-if="visible.avgKmL">{{ avgKmL }}</span>
       </td>
     </tr>
 
@@ -53,14 +55,16 @@
       </td>
     </tr>
 
-    <tr ng-if="visible.instantLph || visible.instantL100km">
+    <tr ng-if="visible.instantLph || visible.instantL100km || visible.instantKmL">
       <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         Instant consumption:
       </td>
       <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         <span ng-if="visible.instantLph">{{ instantLph }}</span>
-        <span ng-if="visible.instantLph && visible.instantL100km"> | </span>
+        <span ng-if="visible.instantLph && (visible.instantL100km || visible.instantKmL)"> | </span>
         <span ng-if="visible.instantL100km">{{ instantL100km }}</span>
+        <span ng-if="visible.instantL100km && visible.instantKmL"> | </span>
+        <span ng-if="visible.instantKmL">{{ instantKmL }}</span>
       </td>
     </tr>
 
@@ -84,12 +88,14 @@
       </td>
     </tr>
 
-    <tr ng-if="visible.tripAvg">
+    <tr ng-if="visible.tripAvgL100km || visible.tripAvgKmL">
       <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         Trip average consumption:
       </td>
       <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
-        {{ data7 }}
+        <span ng-if="visible.tripAvgL100km">{{ tripAvgL100km }}</span>
+        <span ng-if="visible.tripAvgL100km && visible.tripAvgKmL"> | </span>
+        <span ng-if="visible.tripAvgKmL">{{ tripAvgKmL }}</span>
       </td>
     </tr>
 
@@ -164,13 +170,16 @@
     <label><input type="checkbox" ng-model="visible.fuelUsed"> Fuel used</label><br>
     <label><input type="checkbox" ng-model="visible.fuelLeft"> Fuel left</label><br>
     <label><input type="checkbox" ng-model="visible.fuelCap"> Fuel capacity</label><br>
-    <label><input type="checkbox" ng-model="visible.avg"> Average consumption</label><br>
+    <label><input type="checkbox" ng-model="visible.avgL100km"> Average L/100km</label><br>
+    <label><input type="checkbox" ng-model="visible.avgKmL"> Average km/L</label><br>
     <label><input type="checkbox" ng-model="visible.avgGraph"> Average history</label><br>
     <label><input type="checkbox" ng-model="visible.instantLph"> Instant L/h</label><br>
     <label><input type="checkbox" ng-model="visible.instantL100km"> Instant L/100km</label><br>
+    <label><input type="checkbox" ng-model="visible.instantKmL"> Instant km/L</label><br>
     <label><input type="checkbox" ng-model="visible.instantGraph"> Instant history</label><br>
     <label><input type="checkbox" ng-model="visible.range"> Range</label><br>
-    <label><input type="checkbox" ng-model="visible.tripAvg"> Trip average consumption</label><br>
+    <label><input type="checkbox" ng-model="visible.tripAvgL100km"> Trip average L/100km</label><br>
+    <label><input type="checkbox" ng-model="visible.tripAvgKmL"> Trip average km/L</label><br>
     <label><input type="checkbox" ng-model="visible.tripGraph"> Trip average history</label><br>
     <label><input type="checkbox" ng-model="visible.tripDistance"> Trip distance</label><br>
     <label><input type="checkbox" ng-model="visible.tripRange"> Trip range</label><br>

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -86,7 +86,7 @@ describe('UI template styling', () => {
   });
 
   it('provides all data placeholders and icons', () => {
-    const placeholders = ['data1','fuelUsed','fuelLeft','fuelCap','data3','data4','instantLph','instantL100km','instantHistory','data6','data7','data8','data9'];
+    const placeholders = ['data1','fuelUsed','fuelLeft','fuelCap','avgL100km','avgKmL','data4','instantLph','instantL100km','instantKmL','instantHistory','data6','tripAvgL100km','tripAvgKmL','data8','data9'];
     placeholders.forEach(p => {
       assert.ok(html.includes(`{{ ${p} }}`), `missing ${p}`);
     });
@@ -105,9 +105,11 @@ describe('UI template styling', () => {
   it('allows toggling visibility of heading and subfields', () => {
     assert.ok(html.includes('ng-if="visible.distanceMeasured || visible.distanceEcu"'));
     assert.ok(html.includes('ng-if="visible.fuelUsed || visible.fuelLeft || visible.fuelCap"'));
-    assert.ok(html.includes('ng-if="visible.instantLph || visible.instantL100km"'));
+    assert.ok(html.includes('ng-if="visible.avgL100km || visible.avgKmL"'));
+    assert.ok(html.includes('ng-if="visible.instantLph || visible.instantL100km || visible.instantKmL"'));
+    assert.ok(html.includes('ng-if="visible.tripAvgL100km || visible.tripAvgKmL"'));
     assert.ok(html.includes('ng-if="visible.instantGraph"'));
-    const toggles = ['visible.heading','visible.distanceMeasured','visible.distanceEcu','visible.fuelUsed','visible.fuelLeft','visible.fuelCap','visible.instantLph','visible.instantL100km','visible.instantGraph'];
+    const toggles = ['visible.heading','visible.distanceMeasured','visible.distanceEcu','visible.fuelUsed','visible.fuelLeft','visible.fuelCap','visible.avgL100km','visible.avgKmL','visible.instantLph','visible.instantL100km','visible.instantKmL','visible.instantGraph','visible.tripAvgL100km','visible.tripAvgKmL'];
     toggles.forEach(t => {
       assert.ok(html.includes(`ng-model="${t}"`), `missing toggle ${t}`);
     });
@@ -144,7 +146,7 @@ describe('controller integration', () => {
     streams.engineInfo[11] = 49.9;
     $scope.on_streamsUpdate(null, streams);
 
-    const fields = ['data1','fuelUsed','fuelLeft','fuelCap','data3','data4','instantLph','instantL100km','instantHistory','data6','data7','data8','data9'];
+    const fields = ['data1','fuelUsed','fuelLeft','fuelCap','avgL100km','avgKmL','data4','instantLph','instantL100km','instantKmL','instantHistory','data6','tripAvgL100km','tripAvgKmL','data8','data9'];
     fields.forEach(f => {
       assert.notStrictEqual($scope[f], '', `${f} empty`);
     });
@@ -221,6 +223,7 @@ describe('controller integration', () => {
 
     assert.strictEqual($scope.instantLph, '0.0 L/h');
     assert.strictEqual($scope.instantL100km, '0.0 L/100km');
+    assert.strictEqual($scope.instantKmL, 'Infinity');
     assert.strictEqual($scope.instantHistory, '');
   });
 


### PR DESCRIPTION
## Summary
- add km/L readings for average, instant and trip consumption
- allow toggling km/L values in settings alongside existing units
- test visibility toggles and km/L calculations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad9c64178c832998891275c8ac86ae