### PR TITLE
fix: cap instant efficiency values

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -314,6 +314,7 @@ angular.module('beamng.apps')
       var lastInstantUpdate_ms = 0;
       var INSTANT_UPDATE_INTERVAL = 250;
       var MAX_CONSUMPTION = 1000; // [L/100km] ignore unrealistic spikes
+      var MAX_EFFICIENCY = 500; // [km/L] cap unrealistic efficiency
 
       $scope.vehicleNameStr = "";
 
@@ -523,7 +524,8 @@ angular.module('beamng.apps')
           var inst_l_per_100km = engineRunning
             ? calculateInstantConsumption(fuelFlow_lps, speed_mps)
             : 0;
-          var eff = inst_l_per_100km > 0 ? 100 / inst_l_per_100km : Infinity;
+          var eff = inst_l_per_100km > 0 ? 100 / inst_l_per_100km : MAX_EFFICIENCY;
+          eff = Math.min(eff, MAX_EFFICIENCY);
           if (now_ms - lastInstantUpdate_ms >= INSTANT_UPDATE_INTERVAL) {
             $scope.instantLph = formatFlow(inst_l_per_h, $scope.unitMode, 1);
             if (Number.isFinite(inst_l_per_100km)) {
@@ -540,7 +542,7 @@ angular.module('beamng.apps')
             instantHistory.queue.push(inst_l_per_h);
             trimQueue(instantHistory.queue, INSTANT_MAX_ENTRIES);
             $scope.instantHistory = buildQueueGraphPoints(instantHistory.queue, 100, 40);
-            instantEffHistory.queue.push(Number.isFinite(eff) ? eff : 0);
+            instantEffHistory.queue.push(Number.isFinite(eff) ? eff : MAX_EFFICIENCY);
             trimQueue(instantEffHistory.queue, INSTANT_MAX_ENTRIES);
             $scope.instantKmLHistory = buildQueueGraphPoints(instantEffHistory.queue, 100, 40);
             if (!instantHistory.lastSaveTime) instantHistory.lastSaveTime = 0;

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
@@ -1,7 +1,7 @@
 {
   "name" : "Fuel Economy",
   "author": "KRtekTM",
-  "version": "1.0.0.7",
+  "version": "1.0.0.8",
   "description": "Fuel Economy - Average Fuel Consumption",
   "directive": "okFuelEconomy",
   "domElement": "<ok-fuel-economy></ok-fuel-economy>",

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -254,9 +254,46 @@ describe('controller integration', () => {
 
     assert.strictEqual($scope.instantLph, '0.0 L/h');
     assert.strictEqual($scope.instantL100km, '0.0 L/100km');
-    assert.strictEqual($scope.instantKmL, 'Infinity');
+    assert.strictEqual($scope.instantKmL, '500.00 km/L');
     assert.strictEqual($scope.instantHistory, '');
     assert.strictEqual($scope.instantKmLHistory, '');
+  });
+
+  it('caps instant efficiency when coasting', () => {
+    let directiveDef;
+    global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };
+    global.StreamsManager = { add: () => {}, remove: () => {} };
+    global.UiUnits = { buildString: () => '' };
+    global.bngApi = { engineLua: () => '' };
+    global.localStorage = { getItem: () => null, setItem: () => {} };
+    let now = 0;
+    global.performance = { now: () => now };
+
+    delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
+    require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+    const controllerFn = directiveDef.controller[2];
+    const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
+    controllerFn({ debug: () => {} }, $scope);
+
+    const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 10, airspeed: 10, throttle_input: 0.5, rpmTacho: 1000, trip: 0 } };
+    streams.engineInfo[11] = 50;
+    streams.engineInfo[12] = 60;
+
+    now = 0;
+    $scope.on_streamsUpdate(null, streams);
+    now = 1000;
+    streams.engineInfo[11] = 49.99;
+    $scope.on_streamsUpdate(null, streams);
+
+    streams.electrics.throttle_input = 0;
+    for (let i = 0; i < 100; i++) {
+      now += 1000;
+      $scope.on_streamsUpdate(null, streams);
+    }
+
+    const val = parseFloat($scope.instantKmL);
+    assert.notStrictEqual($scope.instantKmLHistory, '');
+    assert.ok(val <= 500, `instantKmL not capped: ${$scope.instantKmL}`);
   });
 
   it('resets instant history when vehicle changes', () => {


### PR DESCRIPTION
## Summary
- avoid infinite values in instant km/L by clamping to realistic maximum
- cap raised to 500 km/L so even ultra-efficient vehicles remain visible
- test instant efficiency capping, adjust expectations when engine stops, and bump app version

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adbef0b6d08329a60eb6c28b0de4e4