### PR TITLE
Add fuel cost calculator

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -1,5 +1,5 @@
 <div class="bngApp"
-     ng-init="useCustomStyles=true"
+     ng-init="useCustomStyles=true; fuelPrice=(+localStorage.getItem('okFuelEconomyFuelPrice')||0)"
      ng-attr-style="{{ 'width:100%; height:100%; overflow:auto; position:relative;' + (useCustomStyles ? ' padding:4px; border-radius:10px; background-color:rgba(10,15,20,0.75); background-image:linear-gradient(rgba(0,200,255,0.05) 1px, transparent 1px), linear-gradient(90deg, rgba(0,200,255,0.05) 1px, transparent 1px); background-size:16px 16px,16px 16px; color:#aeeaff; font-family: Segoe UI, Tahoma, Geneva, Verdana, sans-serif; letter-spacing:0.3px; box-shadow: inset 0 0 10px rgba(0,200,255,0.25);' : '') }}"
      layout="column">
 
@@ -30,6 +30,17 @@
         <span ng-if="visible.fuelLeft">Left: {{ fuelLeft }}</span>
         <span ng-if="visible.fuelLeft && visible.fuelCap"> | </span>
         <span ng-if="visible.fuelCap">Capacity: {{ fuelCap }}</span>
+      </td>
+    </tr>
+
+    <tr ng-if="visible.costTotal || visible.costPerDistance">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; width:38%; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
+        Fuel cost:
+      </td>
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
+        <span ng-if="visible.costTotal">{{ ((unitMode === 'imperial' ? fuelUsedValue / 3.78541 : fuelUsedValue) * (fuelPrice || 0)) | number:2 }} money</span>
+        <span ng-if="visible.costTotal && visible.costPerDistance"> | </span>
+        <span ng-if="visible.costPerDistance">{{ ((unitMode === 'imperial' ? fuelUsedValue / 3.78541 : fuelUsedValue) * (fuelPrice || 0)) / ((unitMode === 'imperial' ? distanceValue / 1609.34 : distanceValue / 1000) || 1) | number:2 }} money/{{ unitDistanceUnit }}</span>
       </td>
     </tr>
 
@@ -161,6 +172,17 @@
       </td>
     </tr>
 
+    <tr ng-if="visible.tripCostTotal || visible.tripCostPerDistance">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
+        Trip cost:
+      </td>
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
+        <span ng-if="visible.tripCostTotal">{{ ((unitMode === 'imperial' ? (tripAvgL100kmValue * tripDistanceValue / 100000) / 3.78541 : (tripAvgL100kmValue * tripDistanceValue / 100000)) * (fuelPrice || 0)) | number:2 }} money</span>
+        <span ng-if="visible.tripCostTotal && visible.tripCostPerDistance"> | </span>
+        <span ng-if="visible.tripCostPerDistance">{{ ((unitMode === 'imperial' ? tripAvgL100kmValue * 1.60934 / 3.78541 / 100 : tripAvgL100kmValue / 100) * (fuelPrice || 0)) | number:2 }} money/{{ unitDistanceUnit }}</span>
+      </td>
+    </tr>
+
     <tr ng-if="visible.tripReset">
       <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         Trip reset:
@@ -220,6 +242,17 @@
       <label><input type="checkbox" ng-model="visible.tripDistance"> Trip distance</label><br>
       <label><input type="checkbox" ng-model="visible.tripRange"> Trip range</label><br>
       <label><input type="checkbox" ng-model="visible.tripReset"> Trip reset</label><br>
+      <label><input type="checkbox" ng-model="visible.costTotal"> Fuel cost total</label><br>
+      <label><input type="checkbox" ng-model="visible.costPerDistance"> Fuel cost per {{ unitDistanceUnit }}</label><br>
+      <label><input type="checkbox" ng-model="visible.tripCostTotal"> Trip cost total</label><br>
+      <label><input type="checkbox" ng-model="visible.tripCostPerDistance"> Trip cost per {{ unitDistanceUnit }}</label><br>
+      <label>Fuel price per {{ unitVolumeUnit }}:
+        <input type="number"
+               ng-model="fuelPrice"
+               ng-change="localStorage.setItem('okFuelEconomyFuelPrice', fuelPrice)"
+               step="0.01"
+               ng-attr-style="{{ 'margin-left:4px; width:60px;' + (useCustomStyles ? ' color:#aeeaff; background:rgba(0,200,255,0.15); border:1px solid #5fdcff;' : '') }}">
+      </label><br>
       <div ng-attr-style="{{ 'position:relative;' + (useCustomStyles ? '' : '') }}">
         <label>Units:
           <span ng-click="unitMenuOpen = !unitMenuOpen"

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -221,6 +221,8 @@ angular.module('beamng.apps')
         $scope.unitConsumptionUnit = lbls.consumption;
         $scope.unitEfficiencyUnit = lbls.efficiency;
         $scope.unitFlowUnit = lbls.flow;
+        $scope.unitVolumeUnit = lbls.volume;
+        $scope.unitDistanceUnit = lbls.distance;
       }
       updateUnitLabels();
       $scope.visible = {
@@ -246,7 +248,11 @@ angular.module('beamng.apps')
         tripKmLGraph: true,
         tripDistance: true,
         tripRange: true,
-        tripReset: true
+        tripReset: true,
+        costTotal: true,
+        costPerDistance: true,
+        tripCostTotal: true,
+        tripCostPerDistance: true
       };
       try {
         var s = JSON.parse(localStorage.getItem(SETTINGS_KEY));
@@ -298,6 +304,11 @@ angular.module('beamng.apps')
       $scope.avgKmLHistory = '';
       $scope.instantHistory = '';
       $scope.instantKmLHistory = '';
+
+      $scope.fuelUsedValue = 0;
+      $scope.distanceValue = 0;
+      $scope.tripDistanceValue = 0;
+      $scope.tripAvgL100kmValue = 0;
 
       var distance_m = 0;
       var lastDistance_m = 0;
@@ -655,6 +666,7 @@ angular.module('beamng.apps')
 
           $scope.data1 = formatDistance(distance_m, $scope.unitMode, 1);
           $scope.fuelUsed = formatVolume(fuel_used_l, $scope.unitMode, 2);
+          $scope.fuelUsedValue = fuel_used_l;
           $scope.fuelLeft = formatVolume(currentFuel_l, $scope.unitMode, 2);
           $scope.fuelCap = formatVolume(capacity_l, $scope.unitMode, 1);
           $scope.avgL100km = formatConsumptionRate(avg_l_per_100km_ok, $scope.unitMode, 1);
@@ -665,6 +677,7 @@ angular.module('beamng.apps')
           );
           $scope.data4 = rangeStr;
           $scope.data6 = formatDistance(trip_m, $scope.unitMode, 1);
+          $scope.distanceValue = distance_m;
           $scope.tripAvgL100km = formatConsumptionRate(overall_median, $scope.unitMode, 1);
           $scope.tripAvgKmL = formatEfficiency(
             overall_median > 0 ? 100 / overall_median : Infinity,
@@ -672,6 +685,8 @@ angular.module('beamng.apps')
             2
           );
           $scope.data8 = formatDistance(overall.distance, $scope.unitMode, 1);
+          $scope.tripDistanceValue = overall.distance;
+          $scope.tripAvgL100kmValue = overall_median;
           $scope.data9 = rangeOverallMedianStr;
           $scope.vehicleNameStr = bngApi.engineLua("be:getPlayerVehicle(0)");
           lastDistance_m = distance_m;

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -86,7 +86,7 @@ describe('UI template styling', () => {
   });
 
   it('provides all data placeholders and icons', () => {
-    const placeholders = ['data1','fuelUsed','fuelLeft','fuelCap','avgL100km','avgKmL','data4','instantLph','instantL100km','instantKmL','instantHistory','instantKmLHistory','data6','tripAvgL100km','tripAvgKmL','tripAvgHistory','tripAvgKmLHistory','avgHistory','avgKmLHistory','data8','data9'];
+    const placeholders = ['data1','fuelUsed','fuelLeft','fuelCap','avgL100km','avgKmL','data4','instantLph','instantL100km','instantKmL','instantHistory','instantKmLHistory','data6','tripAvgL100km','tripAvgKmL','tripAvgHistory','tripAvgKmLHistory','avgHistory','avgKmLHistory','data8','data9','unitVolumeUnit','unitDistanceUnit'];
     placeholders.forEach(p => {
       assert.ok(html.includes(`{{ ${p} }}`), `missing ${p}`);
     });
@@ -109,7 +109,9 @@ describe('UI template styling', () => {
     assert.ok(html.includes('ng-if="visible.instantLph || visible.instantL100km || visible.instantKmL"'));
     assert.ok(html.includes('ng-if="visible.tripAvgL100km || visible.tripAvgKmL"'));
     assert.ok(html.includes('ng-if="visible.instantGraph"'));
-    const toggles = ['visible.heading','visible.distanceMeasured','visible.distanceEcu','visible.fuelUsed','visible.fuelLeft','visible.fuelCap','visible.avgL100km','visible.avgKmL','visible.avgGraph','visible.avgKmLGraph','visible.instantLph','visible.instantL100km','visible.instantKmL','visible.instantGraph','visible.instantKmLGraph','visible.tripAvgL100km','visible.tripAvgKmL','visible.tripGraph','visible.tripKmLGraph'];
+    assert.ok(html.includes('ng-if="visible.costTotal || visible.costPerDistance"'));
+    assert.ok(html.includes('ng-if="visible.tripCostTotal || visible.tripCostPerDistance"'));
+    const toggles = ['visible.heading','visible.distanceMeasured','visible.distanceEcu','visible.fuelUsed','visible.fuelLeft','visible.fuelCap','visible.avgL100km','visible.avgKmL','visible.avgGraph','visible.avgKmLGraph','visible.instantLph','visible.instantL100km','visible.instantKmL','visible.instantGraph','visible.instantKmLGraph','visible.tripAvgL100km','visible.tripAvgKmL','visible.tripGraph','visible.tripKmLGraph','visible.costTotal','visible.costPerDistance','visible.tripCostTotal','visible.tripCostPerDistance'];
     toggles.forEach(t => {
       assert.ok(html.includes(`ng-model="${t}"`), `missing toggle ${t}`);
     });
@@ -149,6 +151,9 @@ describe('controller integration', () => {
     const fields = ['data1','fuelUsed','fuelLeft','fuelCap','avgL100km','avgKmL','data4','instantLph','instantL100km','instantKmL','instantHistory','instantKmLHistory','data6','tripAvgL100km','tripAvgKmL','data8','data9'];
     fields.forEach(f => {
       assert.notStrictEqual($scope[f], '', `${f} empty`);
+    });
+    ['fuelUsedValue','distanceValue','tripDistanceValue','tripAvgL100kmValue'].forEach(f => {
+      assert.strictEqual(typeof $scope[f], 'number');
     });
   });
 


### PR DESCRIPTION
## Summary
- allow users to enter fuel price and calculate total and per-distance cost
- show trip-wide fuel costs based on average consumption
- expose numeric metrics and unit labels for cost calculations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae10fca9f88329ae7490c93a7f14c4