### PR TITLE
feat: link fuel price config for easy editing

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -272,7 +272,9 @@
       <label><input type="checkbox" ng-model="visible.tripTotalCost"> Trip total fuel cost</label><br>
       <p id="fuelPriceNotice"
          ng-attr-style="{{ 'margin:4px 0;' + (useCustomStyles ? ' color:#aeeaff;' : '') }}">
-        Set fuel price and currency in fuelPrice.json
+        Set fuel price and currency in
+        <a href="" ng-click="openFuelPriceConfig()"
+           ng-attr-style="{{ useCustomStyles ? ' color:#aeeaff;' : '' }}">fuelPrice.json</a>
       </p>
       <div ng-attr-style="{{ 'position:relative;' + (useCustomStyles ? '' : '') }}">
         <label>Units:

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -273,7 +273,7 @@
       <p id="fuelPriceNotice"
          ng-attr-style="{{ 'margin:4px 0;' + (useCustomStyles ? ' color:#aeeaff;' : '') }}">
         Set fuel price and currency in
-        <a href="" ng-click="openFuelPriceConfig()"
+        <a href="" ng-click="openFuelPriceConfig($event)"
            ng-attr-style="{{ useCustomStyles ? ' color:#aeeaff;' : '' }}">fuelPrice.json</a>
       </p>
       <div ng-attr-style="{{ 'position:relative;' + (useCustomStyles ? '' : '') }}">

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -328,7 +328,9 @@ angular.module('beamng.apps')
         $scope.settingsOpen = false;
       };
 
-      $scope.openFuelPriceConfig = function () {
+      $scope.openFuelPriceConfig = function (ev) {
+        if (ev && typeof ev.preventDefault === 'function') ev.preventDefault();
+        if (ev && typeof ev.stopPropagation === 'function') ev.stopPropagation();
         if (!fs || !path || !spawn) return;
         try {
           var base = process.env.LOCALAPPDATA || process.env.APPDATA;

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -63,7 +63,7 @@ describe('UI template styling', () => {
     assert.ok(!html.includes('fetch('));
     assert.ok(html.includes('fuelPriceNotice'));
     assert.ok(html.includes('fuel price and currency in'));
-    assert.ok(html.includes('ng-click="openFuelPriceConfig()"'));
+    assert.ok(html.includes('ng-click="openFuelPriceConfig($event)"'));
     assert.ok(html.includes('>fuelPrice.json</a>'));
     assert.ok(!html.includes('<script type="text/javascript">'));
     assert.ok(html.includes('{{ costPrice }}'));
@@ -232,7 +232,9 @@ describe('fuel price config link', () => {
     const $scope = { $on: () => {} };
     controllerFn({ debug: () => {} }, $scope, $http);
 
-    $scope.openFuelPriceConfig();
+    let prevented = false;
+    const ev = { preventDefault: () => { prevented = true; }, stopPropagation: () => {} };
+    $scope.openFuelPriceConfig(ev);
 
     const cfg = path.join(beamBase, '0.99', 'mods', 'unpacked', 'krtektm_FuelEconomy',
       'ui', 'modules', 'apps', 'okFuelEconomy', 'fuelPrice.json');
@@ -241,6 +243,8 @@ describe('fuel price config link', () => {
       { fuelPrice: 0, currency: 'money' });
     assert.strictEqual(spawnArgs[0], 'explorer');
     assert.deepStrictEqual(spawnArgs[1], ['/select,', cfg.replace(/\//g, '\\')]);
+
+    assert.ok(prevented);
 
     cp.spawn = origSpawn;
     Object.defineProperty(process, 'platform', { value: origPlatform });


### PR DESCRIPTION
## Summary
- add hyperlink to open fuelPrice.json from settings
- create helper to open config in Explorer and generate default file when missing
- cover link and opener with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae58e164788329ad82b2bf28263e5f