### PR TITLE
feat: inline fuel price help dialog

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -273,8 +273,23 @@
       <p id="fuelPriceNotice"
          ng-attr-style="{{ 'margin:4px 0;' + (useCustomStyles ? ' color:#aeeaff;' : '') }}">
         Set fuel price and currency in
-        <a href="https://github.com/KRtkovo-eu-AI/BeamNG_Fuel_Economy_mod?tab=readme-ov-file#fuel-price-configuration" ng-attr-style="{{ useCustomStyles ? ' color:#aeeaff;' : '' }}">fuelPrice.json</a>
+        <a href=""
+           ng-click="fuelPriceHelpOpen = true"
+           ng-attr-style="{{ useCustomStyles ? ' color:#aeeaff;' : '' }}">fuelPrice.json</a>
       </p>
+      <div ng-if="fuelPriceHelpOpen"
+           ng-attr-style="{{ 'position:absolute; top:68px; right:4px; z-index:10; padding:8px; border-radius:6px; background:rgba(0,0,0,0.85); max-width:260px;' + (useCustomStyles ? ' color:#aeeaff; border:1px solid #5fdcff;' : ' color:#fff; border:1px solid #ccc; background:#333;') }}">
+        <p ng-attr-style="{{ 'margin:0 0 8px;' + (useCustomStyles ? '' : '') }}">
+          To enable fuel cost calculations, edit
+          <code>krtektm_FuelEconomy.zip/ui/modules/apps/okFuelEconomy/fuelPrice.json</code>
+          and set the <code>fuelPrice</code> value to the price of fuel per volume unit you use
+          and optionally set the <code>currency</code> label (e.g. <code>$</code>, <code>€</code>). The controller loads these values at runtime and computes
+          average cost per distance, trip average cost per distance, total fuel cost and trip total fuel cost when the relevant fields are enabled in settings.
+          If the file is missing, the widget falls back to a price of <code>0</code> and a currency label of <code>money</code> so the calculator still operates.
+        </p>
+        <button ng-click="fuelPriceHelpOpen = false"
+                ng-attr-style="{{ 'font-size:0.8em; padding:2px 6px; cursor:pointer;' + (useCustomStyles ? ' color:#aeeaff; background:rgba(0,200,255,0.15); border:1px solid #5fdcff;' : '') }}">OK</button>
+      </div>
       <div ng-attr-style="{{ 'position:relative;' + (useCustomStyles ? '' : '') }}">
         <label>Units:
           <span ng-click="unitMenuOpen = !unitMenuOpen"

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -233,6 +233,7 @@ angular.module('beamng.apps')
       var SETTINGS_KEY = 'okFuelEconomyVisible';
       var UNIT_MODE_KEY = 'okFuelEconomyUnitMode';
       $scope.settingsOpen = false;
+      $scope.fuelPriceHelpOpen = false;
       $scope.unitModeLabels = {
         metric: 'Metric (L, km)',
         imperial: 'Imperial (gal, mi)',

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -62,7 +62,8 @@ describe('UI template styling', () => {
   it('renders fuel cost bindings without inline script', () => {
     assert.ok(!html.includes('fetch('));
     assert.ok(html.includes('fuelPriceNotice'));
-    assert.ok(html.includes('fuel price and currency in fuelPrice.json'));
+    assert.ok(html.includes('fuel price and currency in'));
+    assert.ok(html.includes('fuelPrice.json'));
     assert.ok(!html.includes('<script type="text/javascript">'));
     assert.ok(html.includes('{{ costPrice }}'));
     assert.ok(html.includes('{{ avgCost }}'));


### PR DESCRIPTION
## Summary
- replace external fuel price link with in-app help dialog showing README instructions
- add Angular scope flag for dialog and update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae5f80a1b883299f61dc278a225b4e