### PR TITLE
feat: support separate liquid and electric fuel costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Data are gathered via `StreamsManager` from the *electrics* and *engineInfo* cha
 ## Fuel price configuration
 
 To enable fuel cost calculations, edit `krtektm_FuelEconomy.zip/ui/modules/apps/okFuelEconomy/fuelPrice.json` and set the `liquidFuelPrice` and `electricityPrice` values to the prices of fuel per volume unit you use and optionally set the `currency` label (e.g. `$`, `€`). The controller loads these values at runtime and computes average cost per distance, trip average cost per distance, total fuel cost and trip total fuel cost when the relevant fields are enabled in settings.
+Trip costs accumulate only while their respective unit mode is active: liquid costs grow when using metric or imperial units, whereas electric costs grow when using the electric unit mode.
 If the file is missing, the widget falls back to a price of `0` and a currency label of `money` so the calculator still operates.
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ This repository contains a UI mod for BeamNG.drive that displays fuel economy in
 - Efficiency history graphs for instant, average and trip consumption with toggleable visibility and custom style support.
 - Hide or show heading and individual data points through an in-app settings dialog that remembers user choices.
 - Switch between the default BeamNG style and a custom neon-themed look.
-- Optional fuel cost calculator showing average, trip average and total costs (both overall and trip) driven by a price set in `fuelPrice.json`.
+- Optional fuel cost calculator showing average, trip average and total costs (both overall and trip) driven by prices set in `fuelPrice.json`.
 
 Data are gathered via `StreamsManager` from the *electrics* and *engineInfo* channels. All calculations are performed client-side using helper functions like `calculateFuelFlow`, `calculateInstantConsumption`, `calculateRange` and `trimQueue`.
 
 ## Fuel price configuration
 
-To enable fuel cost calculations, edit `krtektm_FuelEconomy.zip/ui/modules/apps/okFuelEconomy/fuelPrice.json` and set the `fuelPrice` value to the price of fuel per volume unit you use and optionally set the `currency` label (e.g. `$`, `€`). The controller loads these values at runtime and computes average cost per distance, trip average cost per distance, total fuel cost and trip total fuel cost when the relevant fields are enabled in settings.
+To enable fuel cost calculations, edit `krtektm_FuelEconomy.zip/ui/modules/apps/okFuelEconomy/fuelPrice.json` and set the `liquidFuelPrice` and `electricityPrice` values to the prices of fuel per volume unit you use and optionally set the `currency` label (e.g. `$`, `€`). The controller loads these values at runtime and computes average cost per distance, trip average cost per distance, total fuel cost and trip total fuel cost when the relevant fields are enabled in settings.
 If the file is missing, the widget falls back to a price of `0` and a currency label of `money` so the calculator still operates.
 
 ## Tests

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -193,9 +193,9 @@
         Trip average fuel cost:
       </td>
       <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
-        <span>{{ tripAvgCostLiquid }}</span>
+        <span>Liquid: {{ tripAvgCostLiquid }}</span>
         <span> | </span>
-        <span>{{ tripAvgCostElectric }}</span>
+        <span>Electric: {{ tripAvgCostElectric }}</span>
       </td>
     </tr>
 
@@ -204,9 +204,9 @@
         Trip total fuel cost:
       </td>
       <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
-        <span>{{ tripTotalCostLiquid }}</span>
+        <span>Liquid: {{ tripTotalCostLiquid }}</span>
         <span> | </span>
-        <span>{{ tripTotalCostElectric }}</span>
+        <span>Electric: {{ tripTotalCostElectric }}</span>
       </td>
     </tr>
 

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -193,7 +193,9 @@
         Trip average fuel cost:
       </td>
       <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
-        <span>{{ tripAvgCost }}</span>
+        <span>{{ tripAvgCostLiquid }}</span>
+        <span> | </span>
+        <span>{{ tripAvgCostElectric }}</span>
       </td>
     </tr>
 
@@ -202,7 +204,9 @@
         Trip total fuel cost:
       </td>
       <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
-        <span>{{ tripTotalCost }}</span>
+        <span>{{ tripTotalCostLiquid }}</span>
+        <span> | </span>
+        <span>{{ tripTotalCostElectric }}</span>
       </td>
     </tr>
 
@@ -272,7 +276,7 @@
       <label><input type="checkbox" ng-model="visible.tripTotalCost"> Trip total fuel cost</label><br>
       <p id="fuelPriceNotice"
          ng-attr-style="{{ 'margin:4px 0;' + (useCustomStyles ? ' color:#aeeaff;' : '') }}">
-        Set fuel price and currency in
+        Set fuel prices and currency in
         <a href=""
            ng-click="openFuelPriceHelp($event)"
            ng-attr-style="{{ useCustomStyles ? ' color:#aeeaff;' : '' }}">fuelPrice.json</a>
@@ -282,7 +286,7 @@
         <p ng-attr-style="{{ 'margin:0 0 8px;' + (useCustomStyles ? '' : '') }}">
           To enable fuel cost calculations, edit
           <strong>krtektm_FuelEconomy.zip/<wbr>ui/<wbr>modules/<wbr>apps/<wbr>okFuelEconomy/<wbr>fuelPrice.json</strong>
-          and set the <strong>fuelPrice</strong> value to the price of fuel per volume unit you use
+          and set the <strong>liquidFuelPrice</strong> and <strong>electricityPrice</strong> values to the prices of fuel per volume unit you use
           and optionally set the <strong>currency</strong> label (e.g. <strong>$</strong>, <strong>€</strong>).
         </p>
         <button type="button"

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -213,15 +213,20 @@ angular.module('beamng.apps')
       var streamsList = ['electrics', 'engineInfo'];
       StreamsManager.add(streamsList);
 
-      $scope.fuelPriceValue = 0;
+      $scope.liquidFuelPriceValue = 0;
+      $scope.electricityPriceValue = 0;
       $scope.currency = 'money';
       $http.get('/ui/modules/apps/okFuelEconomy/fuelPrice.json')
         .then(function (resp) {
-          $scope.fuelPriceValue = parseFloat((resp.data || {}).fuelPrice) || 0;
+          $scope.liquidFuelPriceValue =
+            parseFloat((resp.data || {}).liquidFuelPrice) || 0;
+          $scope.electricityPriceValue =
+            parseFloat((resp.data || {}).electricityPrice) || 0;
           $scope.currency = (resp.data || {}).currency || 'money';
         })
         .catch(function () {
-          $scope.fuelPriceValue = 0;
+          $scope.liquidFuelPriceValue = 0;
+          $scope.electricityPriceValue = 0;
           $scope.currency = 'money';
         });
 
@@ -352,8 +357,10 @@ angular.module('beamng.apps')
       $scope.costPrice = '';
       $scope.avgCost = '';
       $scope.totalCost = '';
-      $scope.tripAvgCost = '';
-      $scope.tripTotalCost = '';
+      $scope.tripAvgCostLiquid = '';
+      $scope.tripAvgCostElectric = '';
+      $scope.tripTotalCostLiquid = '';
+      $scope.tripTotalCostElectric = '';
 
       var distance_m = 0;
       var lastDistance_m = 0;
@@ -487,8 +494,10 @@ angular.module('beamng.apps')
           tripFuelUsed_l = 0;
           $scope.tripAvgL100km = formatConsumptionRate(0, $scope.unitMode, 1);
           $scope.tripAvgKmL = formatEfficiency(Infinity, $scope.unitMode, 2);
-          $scope.tripAvgCost = '';
-          $scope.tripTotalCost = '';
+          $scope.tripAvgCostLiquid = '';
+          $scope.tripAvgCostElectric = '';
+          $scope.tripTotalCostLiquid = '';
+          $scope.tripTotalCostElectric = '';
           $scope.data6 = formatDistance(0, $scope.unitMode, 1); // reset trip
           $scope.tripAvgHistory = '';
           $scope.tripAvgKmLHistory = '';
@@ -731,27 +740,42 @@ angular.module('beamng.apps')
                          : 'Infinity';
 
           var unitLabels = getUnitLabels($scope.unitMode);
+          var priceForMode =
+            $scope.unitMode === 'electric'
+              ? $scope.electricityPriceValue
+              : $scope.liquidFuelPriceValue;
           $scope.costPrice =
-            $scope.fuelPriceValue.toFixed(2) + ' ' + $scope.currency + '/' + unitLabels.volume;
+            priceForMode.toFixed(2) + ' ' + $scope.currency + '/' + unitLabels.volume;
 
           var fuelUsedUnit = convertVolumeToUnit(fuel_used_l, $scope.unitMode);
-          var totalCostVal = fuelUsedUnit * $scope.fuelPriceValue;
+          var totalCostVal = fuelUsedUnit * priceForMode;
           $scope.totalCost = totalCostVal.toFixed(2) + ' ' + $scope.currency;
 
           var avgLitersPerKm = avg_l_per_100km_ok / 100;
           var avgVolPerDistUnit = convertVolumePerDistance(avgLitersPerKm, $scope.unitMode);
-          var avgCostVal = avgVolPerDistUnit * $scope.fuelPriceValue;
+          var avgCostVal = avgVolPerDistUnit * priceForMode;
           $scope.avgCost =
             avgCostVal.toFixed(2) + ' ' + $scope.currency + '/' + unitLabels.distance;
 
           var tripLitersPerKm = overall_median / 100;
           var tripVolPerDistUnit = convertVolumePerDistance(tripLitersPerKm, $scope.unitMode);
-          var tripAvgCostVal = tripVolPerDistUnit * $scope.fuelPriceValue;
-          $scope.tripAvgCost =
-            tripAvgCostVal.toFixed(2) + ' ' + $scope.currency + '/' + unitLabels.distance;
+          var tripAvgCostLiquidVal =
+            tripVolPerDistUnit * $scope.liquidFuelPriceValue;
+          var tripAvgCostElectricVal =
+            tripVolPerDistUnit * $scope.electricityPriceValue;
+          $scope.tripAvgCostLiquid =
+            tripAvgCostLiquidVal.toFixed(2) + ' ' + $scope.currency + '/' + unitLabels.distance;
+          $scope.tripAvgCostElectric =
+            tripAvgCostElectricVal.toFixed(2) + ' ' + $scope.currency + '/' + unitLabels.distance;
           var tripFuelUsedUnit = convertVolumeToUnit(tripFuelUsed_l, $scope.unitMode);
-          var tripTotalCostVal = tripFuelUsedUnit * $scope.fuelPriceValue;
-          $scope.tripTotalCost = tripTotalCostVal.toFixed(2) + ' ' + $scope.currency;
+          var tripTotalCostLiquidVal =
+            tripFuelUsedUnit * $scope.liquidFuelPriceValue;
+          var tripTotalCostElectricVal =
+            tripFuelUsedUnit * $scope.electricityPriceValue;
+          $scope.tripTotalCostLiquid =
+            tripTotalCostLiquidVal.toFixed(2) + ' ' + $scope.currency;
+          $scope.tripTotalCostElectric =
+            tripTotalCostElectricVal.toFixed(2) + ' ' + $scope.currency;
 
           $scope.data1 = formatDistance(distance_m, $scope.unitMode, 1);
           $scope.fuelUsed = formatVolume(fuel_used_l, $scope.unitMode, 2);

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -581,6 +581,10 @@ angular.module('beamng.apps')
             distance_m = 0;
           }
 
+          if (currentFuel_l <= 0 && previousFuel_l > 0.1) {
+            currentFuel_l = previousFuel_l;
+          }
+
           var fuel_used_l = startFuel_l - currentFuel_l;
           if (fuel_used_l >= capacity_l || fuel_used_l < 0) {
             startFuel_l = currentFuel_l;

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -595,13 +595,15 @@ angular.module('beamng.apps')
 
           if (engineRunning) {
             var deltaTripFuel = previousFuel_l - currentFuel_l;
-            if (deltaTripFuel > 0 && deltaTripFuel < capacity_l) {
-              tripFuelUsed_l += deltaTripFuel;
-              overall.fuelUsed = tripFuelUsed_l;
+            if (Math.abs(deltaTripFuel) < capacity_l) {
+              if (deltaTripFuel > 0) {
+                tripFuelUsed_l += deltaTripFuel;
+                overall.fuelUsed = tripFuelUsed_l;
+              }
               var deltaFuelUnit = convertVolumeToUnit(deltaTripFuel, $scope.unitMode);
               if ($scope.unitMode === 'electric') {
                 tripCostElectric += deltaFuelUnit * $scope.electricityPriceValue;
-              } else {
+              } else if (deltaTripFuel > 0) {
                 tripCostLiquid += deltaFuelUnit * $scope.liquidFuelPriceValue;
               }
             }

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -809,10 +809,10 @@ angular.module('beamng.apps')
           $scope.avgCost =
             avgCostVal.toFixed(2) + ' ' + $scope.currency + '/' + unitLabels.distance;
 
-          var tripDistanceLiquidUnit = convertDistanceToUnit(tripDistanceLiquid_m, $scope.unitMode);
-          var tripDistanceElectricUnit = convertDistanceToUnit(tripDistanceElectric_m, $scope.unitMode);
-          var tripAvgCostLiquidVal = tripDistanceLiquidUnit > 0 ? tripCostLiquid / tripDistanceLiquidUnit : 0;
-          var tripAvgCostElectricVal = tripDistanceElectricUnit > 0 ? tripCostElectric / tripDistanceElectricUnit : 0;
+          var medianLitersPerKm = overall_median / 100;
+          var medianVolPerDistUnit = convertVolumePerDistance(medianLitersPerKm, $scope.unitMode);
+          var tripAvgCostLiquidVal = medianVolPerDistUnit * $scope.liquidFuelPriceValue;
+          var tripAvgCostElectricVal = medianVolPerDistUnit * $scope.electricityPriceValue;
           $scope.tripAvgCostLiquid =
             tripAvgCostLiquidVal.toFixed(2) + ' ' + $scope.currency + '/' + unitLabels.distance;
           $scope.tripAvgCostElectric =

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
@@ -1,7 +1,7 @@
 {
   "name" : "Fuel Economy",
   "author": "KRtekTM",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Fuel Economy - Average Fuel Consumption",
   "directive": "okFuelEconomy",
   "domElement": "<ok-fuel-economy></ok-fuel-economy>",

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/fuelPrice.json
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/fuelPrice.json
@@ -1,4 +1,5 @@
 {
-  "fuelPrice": 0,
+  "liquidFuelPrice": 0,
+  "electricityPrice": 0,
   "currency": "money"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beamng-fuel-economy-mod",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "BeamNG fuel economy mod",
   "scripts": {
     "test": "node --test"

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -68,10 +68,10 @@ describe('UI template styling', () => {
     assert.ok(html.includes('{{ costPrice }}'));
     assert.ok(html.includes('{{ avgCost }}'));
     assert.ok(html.includes('{{ totalCost }}'));
-    assert.ok(html.includes('{{ tripAvgCostLiquid }}'));
-    assert.ok(html.includes('{{ tripAvgCostElectric }}'));
-    assert.ok(html.includes('{{ tripTotalCostLiquid }}'));
-    assert.ok(html.includes('{{ tripTotalCostElectric }}'));
+    assert.ok(html.includes('Liquid: {{ tripAvgCostLiquid }}'));
+    assert.ok(html.includes('Electric: {{ tripAvgCostElectric }}'));
+    assert.ok(html.includes('Liquid: {{ tripTotalCostLiquid }}'));
+    assert.ok(html.includes('Electric: {{ tripTotalCostElectric }}'));
   });
 
   it('toggles fuel price help dialog via controller functions', async () => {
@@ -279,18 +279,32 @@ describe('controller integration', () => {
     assert.strictEqual($scope.avgCost, '0.15 USD/km');
     assert.strictEqual($scope.totalCost, '3.00 USD');
     assert.strictEqual($scope.tripAvgCostLiquid, '0.15 USD/km');
+    assert.strictEqual($scope.tripAvgCostElectric, '0.00 USD/km');
+    assert.strictEqual($scope.tripTotalCostLiquid, '3.00 USD');
+    assert.strictEqual($scope.tripTotalCostElectric, '0.00 USD');
+
+    $scope.setUnit('electric');
+    streams.engineInfo[11] = 56;
+    now = 200000;
+    $scope.on_streamsUpdate(null, streams);
+    assert.strictEqual($scope.costPrice, '0.50 USD/kWh');
+    assert.strictEqual($scope.avgCost, '0.05 USD/km');
+    assert.strictEqual($scope.totalCost, '2.00 USD');
+    assert.strictEqual($scope.tripAvgCostLiquid, '0.15 USD/km');
     assert.strictEqual($scope.tripAvgCostElectric, '0.05 USD/km');
     assert.strictEqual($scope.tripTotalCostLiquid, '3.00 USD');
     assert.strictEqual($scope.tripTotalCostElectric, '1.00 USD');
 
-    $scope.setUnit('electric');
+    $scope.setUnit('metric');
+    streams.engineInfo[11] = 54;
+    now = 300000;
     $scope.on_streamsUpdate(null, streams);
-    assert.strictEqual($scope.costPrice, '0.50 USD/kWh');
-    assert.strictEqual($scope.avgCost, '0.05 USD/km');
-    assert.strictEqual($scope.totalCost, '1.00 USD');
+    assert.strictEqual($scope.costPrice, '1.50 USD/L');
+    assert.strictEqual($scope.avgCost, '0.15 USD/km');
+    assert.strictEqual($scope.totalCost, '9.00 USD');
     assert.strictEqual($scope.tripAvgCostLiquid, '0.15 USD/km');
     assert.strictEqual($scope.tripAvgCostElectric, '0.05 USD/km');
-    assert.strictEqual($scope.tripTotalCostLiquid, '3.00 USD');
+    assert.strictEqual($scope.tripTotalCostLiquid, '6.00 USD');
     assert.strictEqual($scope.tripTotalCostElectric, '1.00 USD');
   });
 

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -462,7 +462,7 @@ describe('controller integration', () => {
     assert.strictEqual(stored.tripCostLiquid, 4.5);
   });
 
-  it('ignores zero fuel reading when engine stops', async () => {
+  it('avoids spurious tank drop when engine shuts off', async () => {
     let directiveDef;
     global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };
     global.StreamsManager = { add: () => {}, remove: () => {} };
@@ -496,10 +496,18 @@ describe('controller integration', () => {
     assert.strictEqual($scope.tripTotalCostLiquid, '32.50 money');
     assert.strictEqual($scope.tripTotalCostElectric, '0.00 money');
 
-    streams.electrics.rpmTacho = 0;
+    streams.electrics.rpmTacho = 500;
     streams.electrics.throttle_input = 0;
     streams.engineInfo[11] = 0;
     now = 2000;
+    $scope.on_streamsUpdate(null, streams);
+
+    assert.strictEqual($scope.tripTotalCostLiquid, '32.50 money');
+    assert.strictEqual($scope.tripTotalCostElectric, '0.00 money');
+
+    streams.electrics.rpmTacho = 0;
+    streams.engineInfo[11] = 0;
+    now = 3000;
     $scope.on_streamsUpdate(null, streams);
 
     assert.strictEqual($scope.tripTotalCostLiquid, '32.50 money');


### PR DESCRIPTION
## Summary
- allow configuring separate liquid fuel and electricity prices
- show both liquid and electric trip cost values in UI
- test cost calculations for both price types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af13ab1e248329beda2340d0393232