### PR TITLE
Handle regenerative braking in instant consumption

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -21,6 +21,10 @@ function smoothFuelFlow(
   idleFuelFlow_lps,
   EPS_SPEED
 ) {
+  if (fuelFlow_lps < 0) {
+    // Negative flow means energy is being returned (regen) – use directly.
+    return fuelFlow_lps;
+  }
   if (fuelFlow_lps > 0 && throttle > 0.05) {
     // A fresh reading while throttle is applied – use it directly.
     return fuelFlow_lps;

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -134,6 +134,10 @@ describe('app.js utility functions', () => {
       assert.ok(flow1 < last);
       assert.ok(flow2 < flow1);
     });
+    it('passes through negative flow for regeneration', () => {
+      const res = smoothFuelFlow(-0.01, 10, 0, 0, 0, EPS_SPEED);
+      assert.strictEqual(res, -0.01);
+    });
   });
 
   describe('calculateRange', () => {

--- a/tests/regeneration.test.js
+++ b/tests/regeneration.test.js
@@ -1,0 +1,68 @@
+const assert = require('node:assert');
+const { describe, it } = require('node:test');
+
+// Stub minimal angular object so the module can be required in Node.
+global.angular = { module: () => ({ directive: () => ({}) }) };
+
+const {
+  calculateFuelFlow,
+  calculateInstantConsumption,
+  smoothFuelFlow
+} = require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+
+function pseudoRandom(seed) {
+  let x = seed;
+  return () => {
+    x = (x * 16807) % 2147483647;
+    return (x - 1) / 2147483646;
+  };
+}
+
+describe('regeneration scenario', () => {
+  it('produces negative instant consumption during regenerative braking', () => {
+    const rand = pseudoRandom(42);
+    const dt = 1;
+    const EPS_SPEED = 0.005;
+    let previousFuel = 50;
+    let lastFlow = 0;
+    let idleFlow = 0;
+    let sawRegen = false;
+
+    for (let i = 0; i < 200; i++) {
+      const r = rand();
+      let throttle, speed, delta;
+      if (r < 0.25) {
+        throttle = 0.5;
+        speed = 5 + rand() * 10;
+        delta = -0.001 - rand() * 0.002;
+      } else if (r < 0.5) {
+        throttle = 0;
+        speed = 5 + rand() * 10;
+        delta = -0.0001 * rand();
+      } else if (r < 0.75) {
+        throttle = 1;
+        speed = 10 + rand() * 20;
+        delta = -0.003 - rand() * 0.003;
+      } else {
+        throttle = 0;
+        speed = 5 + rand() * 10;
+        delta = 0.002 + rand() * 0.002;
+      }
+
+      const currentFuel = previousFuel + delta;
+      const rawFlow = calculateFuelFlow(currentFuel, previousFuel, dt);
+      const flow = smoothFuelFlow(rawFlow, speed, throttle, lastFlow, idleFlow, EPS_SPEED);
+      const inst = calculateInstantConsumption(flow, speed);
+
+      if (rawFlow < 0) {
+        assert.ok(inst < 0, 'regeneration should yield negative consumption');
+        sawRegen = true;
+      }
+
+      previousFuel = currentFuel;
+      lastFlow = flow;
+    }
+
+    assert.ok(sawRegen, 'expected at least one regenerative event');
+  });
+});


### PR DESCRIPTION
## Summary
- Allow negative fuel flow to represent regenerative braking and show negative instant consumption for electric mode
- Test smoothFuelFlow negative pass-through and a randomized driving scenario with braking regeneration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afa614a2b483298464358e852b220f