### PR TITLE
Allow editing fuel prices in-game

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,16 @@ This repository contains a UI mod for BeamNG.drive that displays fuel economy in
 - Efficiency history graphs for instant, average and trip consumption with toggleable visibility and custom style support.
 - Hide or show heading and individual data points through an in-app settings dialog that remembers user choices.
 - Switch between the default BeamNG style and a custom neon-themed look.
-- Optional fuel cost calculator showing average, trip average and total costs (both overall and trip) driven by prices set in `fuelPrice.json`.
+- Optional fuel cost calculator showing average, trip average and total costs (both overall and trip) driven by prices editable in the in-game settings dialog.
 
 Data are gathered via `StreamsManager` from the *electrics* and *engineInfo* channels. All calculations are performed client-side using helper functions like `calculateFuelFlow`, `calculateInstantConsumption`, `calculateRange` and `trimQueue`.
 
 ## Fuel price configuration
 
-To enable fuel cost calculations, edit `krtektm_FuelEconomy.zip/ui/modules/apps/okFuelEconomy/fuelPrice.json` and set the `liquidFuelPrice` and `electricityPrice` values to the prices of fuel per volume unit you use and optionally set the `currency` label (e.g. `$`, `€`). The controller loads these values at runtime and computes average cost per distance, trip average cost per distance, total fuel cost and trip total fuel cost when the relevant fields are enabled in settings.
-Trip costs accumulate only while their respective unit mode is active: liquid costs grow when using metric or imperial units, whereas electric costs grow when using the electric unit mode.
-If the file is missing, the widget falls back to a price of `0` and a currency label of `money` so the calculator still operates.
+Fuel prices can be adjusted directly in-game. Open the app's settings dialog and enter the liquid fuel price per selected volume unit, the electricity price per kWh and the currency label, then click **Save**.
+
+These values are stored in `AppData/Local/BeamNG.drive/{version}/settings/krtektm_fuelEconomy/fuelPrice.json` (for example `C:/Users/<your user>/AppData/Local/BeamNG.drive/<version>/settings/krtektm_fuelEconomy/fuelPrice.json` on Windows). Manual edits to this file while the game is running are applied automatically so prices can be changed without restarting.
+Trip costs accumulate only while their respective unit mode is active: liquid costs grow when using metric or imperial units, whereas electric costs grow when using the electric unit mode. If the file is missing, the widget falls back to a price of `0` and a currency label of `money` so the calculator still operates.
 
 ## Tests
 

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -286,25 +286,15 @@
       <label><input type="checkbox" ng-model="visible.totalCost"> Total fuel cost</label><br>
       <label><input type="checkbox" ng-model="visible.tripAvgCost"> Trip average fuel cost per {{ unitDistanceUnit }}</label><br>
       <label><input type="checkbox" ng-model="visible.tripTotalCost"> Trip total fuel cost</label><br>
-      <p id="fuelPriceNotice"
-         ng-attr-style="{{ 'margin:4px 0;' + (useCustomStyles ? ' color:#aeeaff;' : '') }}">
-        Set fuel prices and currency in
-        <a href=""
-           ng-click="openFuelPriceHelp($event)"
-           ng-attr-style="{{ useCustomStyles ? ' color:#aeeaff;' : '' }}">fuelPrice.json</a>
-      </p>
-      <div ng-if="fuelPriceHelpOpen"
-           ng-attr-style="{{ 'position:absolute; top:68px; right:4px; z-index:10; padding:8px; border-radius:6px; background:rgba(0,0,0,0.85); max-width:260px;' + (useCustomStyles ? ' color:#aeeaff; border:1px solid #5fdcff;' : ' color:#fff; border:1px solid #ccc; background:#333;') }}">
-        <p ng-attr-style="{{ 'margin:0 0 8px;' + (useCustomStyles ? '' : '') }}">
-          To enable fuel cost calculations, edit
-          <strong>krtektm_FuelEconomy.zip/<wbr>ui/<wbr>modules/<wbr>apps/<wbr>okFuelEconomy/<wbr>fuelPrice.json</strong>
-          and set the <strong>liquidFuelPrice</strong> and <strong>electricityPrice</strong> values to the prices of fuel per volume unit you use
-          and optionally set the <strong>currency</strong> label (e.g. <strong>$</strong>, <strong>€</strong>).
-        </p>
-        <button type="button"
-                ng-click="closeFuelPriceHelp()"
-                ng-attr-style="{{ 'font-size:0.8em; padding:2px 6px; cursor:pointer;' + (useCustomStyles ? ' color:#aeeaff; background:rgba(0,200,255,0.15); border:1px solid #5fdcff;' : '') }}">OK</button>
-      </div>
+      <label>Liquid fuel price per {{ unitVolumeUnit }}:
+        <input type="number" ng-model="liquidFuelPriceValue">
+      </label><br>
+      <label>Electricity price per kWh:
+        <input type="number" ng-model="electricityPriceValue">
+      </label><br>
+      <label>Currency:
+        <input type="text" ng-model="currency">
+      </label><br>
       <div ng-attr-style="{{ 'position:relative;' + (useCustomStyles ? '' : '') }}">
         <label>Units:
           <span ng-click="unitMenuOpen = !unitMenuOpen"

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -244,6 +244,165 @@ if (typeof module !== 'undefined') {
   };
 }
 
+function loadFuelPriceConfig(callback) {
+  var defaults = {
+    liquidFuelPrice: 0,
+    electricityPrice: 0,
+    currency: 'money'
+  };
+
+  if (typeof require === 'function' && typeof process !== 'undefined') {
+    try {
+      const fs = require('fs');
+      const path = require('path');
+      const cfg = JSON.parse(
+        fs.readFileSync(path.join(__dirname, 'fuelPrice.json'), 'utf8')
+      );
+      defaults = cfg;
+
+      const baseDir =
+        process.env.KRTEKTM_BNG_USER_DIR ||
+        path.join(
+          process.platform === 'win32'
+            ? process.env.LOCALAPPDATA || ''
+            : path.join(process.env.HOME || '', '.local', 'share'),
+          'BeamNG.drive'
+        );
+
+      const versions = fs
+        .readdirSync(baseDir, { withFileTypes: true })
+        .filter(d => d.isDirectory())
+        .map(d => d.name)
+        .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+      const latest = versions[versions.length - 1];
+      if (!latest) {
+        if (typeof callback === 'function') callback(defaults);
+        return defaults;
+      }
+      const settingsDir = path.join(
+        baseDir,
+        latest,
+        'settings',
+        'krtektm_fuelEconomy'
+      );
+      fs.mkdirSync(settingsDir, { recursive: true });
+      const userFile = path.join(settingsDir, 'fuelPrice.json');
+      if (!fs.existsSync(userFile)) {
+        fs.copyFileSync(path.join(__dirname, 'fuelPrice.json'), userFile);
+        if (typeof callback === 'function') callback(defaults);
+        return defaults;
+      }
+      const data = JSON.parse(fs.readFileSync(userFile, 'utf8'));
+      const cfgObj = {
+        liquidFuelPrice: parseFloat(data.liquidFuelPrice) || 0,
+        electricityPrice: parseFloat(data.electricityPrice) || 0,
+        currency: data.currency || 'money'
+      };
+      if (typeof callback === 'function') callback(cfgObj);
+      return cfgObj;
+    } catch (e) {
+      if (typeof callback === 'function') callback(defaults);
+      return defaults;
+    }
+  }
+
+  if (typeof bngApi !== 'undefined' && typeof bngApi.engineLua === 'function') {
+    try {
+      const lua = [
+        '(function()',
+        "local user=(core_paths and core_paths.getUserPath and core_paths.getUserPath()) or ''",
+        "local dir=user..'settings/krtektm_fuelEconomy/'",
+        'FS:directoryCreate(dir)',
+        "local p=dir..'fuelPrice.json'",
+        'local cfg=jsonReadFile(p)',
+        "if not cfg then cfg={liquidFuelPrice=0,electricityPrice=0,currency='money'} jsonWriteFile(p,cfg) end",
+        "return jsonEncode({liquidFuelPrice=tonumber(cfg.liquidFuelPrice) or 0,electricityPrice=tonumber(cfg.electricityPrice) or 0,currency=cfg.currency or 'money'})",
+        'end)()'
+      ].join('\n');
+      bngApi.engineLua(lua, function (res) {
+        var cfg = defaults;
+        try { cfg = JSON.parse(res); } catch (e) { /* ignore */ }
+        if (typeof callback === 'function') callback(cfg);
+      });
+    } catch (e) {
+      if (typeof callback === 'function') callback(defaults);
+    }
+    return defaults;
+  }
+
+  if (typeof callback === 'function') callback(defaults);
+  return defaults;
+}
+
+function saveFuelPriceConfig(cfg, callback) {
+  var data = {
+    liquidFuelPrice: Number(cfg.liquidFuelPrice) || 0,
+    electricityPrice: Number(cfg.electricityPrice) || 0,
+    currency: cfg.currency || 'money'
+  };
+
+  if (typeof require === 'function' && typeof process !== 'undefined') {
+    try {
+      const fs = require('fs');
+      const path = require('path');
+      const baseDir =
+        process.env.KRTEKTM_BNG_USER_DIR ||
+        path.join(
+          process.platform === 'win32'
+            ? process.env.LOCALAPPDATA || ''
+            : path.join(process.env.HOME || '', '.local', 'share'),
+          'BeamNG.drive'
+        );
+      const versions = fs
+        .readdirSync(baseDir, { withFileTypes: true })
+        .filter(d => d.isDirectory())
+        .map(d => d.name)
+        .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+      const latest = versions[versions.length - 1] || '0';
+      const settingsDir = path.join(
+        baseDir,
+        latest,
+        'settings',
+        'krtektm_fuelEconomy'
+      );
+      fs.mkdirSync(settingsDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(settingsDir, 'fuelPrice.json'),
+        JSON.stringify(data)
+      );
+      if (typeof callback === 'function') callback();
+    } catch (e) {
+      if (typeof callback === 'function') callback(e);
+    }
+    return;
+  }
+
+  if (typeof bngApi !== 'undefined' && typeof bngApi.engineLua === 'function') {
+    try {
+      var json = JSON.stringify(data)
+        .replace(/\\/g, '\\\\')
+        .replace(/"/g, '\\"');
+      var lua = [
+        '(function()',
+        "local user=(core_paths and core_paths.getUserPath and core_paths.getUserPath()) or ''",
+        "local dir=user..'settings/krtektm_fuelEconomy/'",
+        'FS:directoryCreate(dir)',
+        "local p=dir..'fuelPrice.json'",
+        "jsonWriteFile(p,jsonDecode(\"" + json + "\"))",
+        'end)()'
+      ].join('\n');
+      bngApi.engineLua(lua, function () {
+        if (typeof callback === 'function') callback();
+      });
+    } catch (e) {
+      if (typeof callback === 'function') callback(e);
+    }
+    return;
+  }
+
+  if (typeof callback === 'function') callback(new Error('no save method'));
+}
+
 angular.module('beamng.apps')
 .directive('okFuelEconomy', [function () {
   return {
@@ -251,43 +410,54 @@ angular.module('beamng.apps')
     replace: true,
     restrict: 'EA',
     scope: true,
-    controller: ['$log', '$scope', '$http', function ($log, $scope, $http) {
+    controller: ['$log', '$scope', function ($log, $scope) {
       var streamsList = ['electrics', 'engineInfo'];
       StreamsManager.add(streamsList);
 
       $scope.liquidFuelPriceValue = 0;
       $scope.electricityPriceValue = 0;
       $scope.currency = 'money';
-      $http.get('/ui/modules/apps/okFuelEconomy/fuelPrice.json')
-        .then(function (resp) {
-          $scope.liquidFuelPriceValue =
-            parseFloat((resp.data || {}).liquidFuelPrice) || 0;
-          $scope.electricityPriceValue =
-            parseFloat((resp.data || {}).electricityPrice) || 0;
-          $scope.currency = (resp.data || {}).currency || 'money';
-        })
-        .catch(function () {
-          $scope.liquidFuelPriceValue = 0;
-          $scope.electricityPriceValue = 0;
-          $scope.currency = 'money';
+      loadFuelPriceConfig(function (cfg) {
+        var applyInit = function () {
+          $scope.liquidFuelPriceValue = cfg.liquidFuelPrice;
+          $scope.electricityPriceValue = cfg.electricityPrice;
+          $scope.currency = cfg.currency;
+        };
+        if (typeof $scope.$evalAsync === 'function') $scope.$evalAsync(applyInit); else applyInit();
+      });
+
+      var pollMs = 1000;
+      if (typeof process !== 'undefined' && process.env && process.env.KRTEKTM_FUEL_POLL_MS) {
+        var intVal = parseInt(process.env.KRTEKTM_FUEL_POLL_MS, 10);
+        if (intVal > 0) pollMs = intVal;
+      }
+      var priceTimer = setInterval(function () {
+        loadFuelPriceConfig(function (cfg) {
+          if (
+            cfg.liquidFuelPrice !== $scope.liquidFuelPriceValue ||
+            cfg.electricityPrice !== $scope.electricityPriceValue ||
+            cfg.currency !== $scope.currency
+          ) {
+            var apply = function () {
+              $scope.liquidFuelPriceValue = cfg.liquidFuelPrice;
+              $scope.electricityPriceValue = cfg.electricityPrice;
+              $scope.currency = cfg.currency;
+            };
+            if (typeof $scope.$evalAsync === 'function') $scope.$evalAsync(apply); else apply();
+          }
         });
+      }, pollMs);
+      if (priceTimer.unref) priceTimer.unref();
 
       $scope.$on('$destroy', function () {
         StreamsManager.remove(streamsList);
+        clearInterval(priceTimer);
       });
 
       // Settings for visible fields
       var SETTINGS_KEY = 'okFuelEconomyVisible';
       var UNIT_MODE_KEY = 'okFuelEconomyUnitMode';
       $scope.settingsOpen = false;
-      $scope.fuelPriceHelpOpen = false;
-      $scope.openFuelPriceHelp = function ($event) {
-        $event.preventDefault();
-        $scope.fuelPriceHelpOpen = true;
-      };
-      $scope.closeFuelPriceHelp = function () {
-        $scope.fuelPriceHelpOpen = false;
-      };
       $scope.unitModeLabels = {
         metric: 'Metric (L, km)',
         imperial: 'Imperial (gal, mi)',
@@ -306,6 +476,7 @@ angular.module('beamng.apps')
         $scope.unitEfficiencyUnit = lbls.efficiency;
         $scope.unitFlowUnit = lbls.flow;
         $scope.unitDistanceUnit = lbls.distance;
+        $scope.unitVolumeUnit = lbls.volume;
       }
       updateUnitLabels();
       $scope.visible = {
@@ -374,6 +545,11 @@ angular.module('beamng.apps')
           localStorage.setItem(SETTINGS_KEY, JSON.stringify($scope.visible));
           localStorage.setItem(UNIT_MODE_KEY, $scope.unitMode);
         } catch (e) { /* ignore */ }
+        saveFuelPriceConfig({
+          liquidFuelPrice: $scope.liquidFuelPriceValue,
+          electricityPrice: $scope.electricityPriceValue,
+          currency: $scope.currency
+        });
         $scope.settingsOpen = false;
       };
 

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -2,7 +2,6 @@ const assert = require('node:assert');
 const { describe, it } = require('node:test');
 const fs = require('fs');
 const path = require('path');
-const httpStub = { get: () => Promise.resolve({ data: { liquidFuelPrice: 0, electricityPrice: 0, currency: 'money' } }) };
 
 const htmlPath = path.join(__dirname, '..', 'okFuelEconomy', 'ui', 'modules', 'apps', 'okFuelEconomy', 'app.html');
 const html = fs.readFileSync(htmlPath, 'utf8');
@@ -59,11 +58,11 @@ describe('UI template styling', () => {
     assert.ok(!styleTrue.includes("url('app.png')"));
   });
 
-  it('renders fuel cost bindings without inline script', () => {
+  it('renders fuel price inputs without inline script', () => {
     assert.ok(!html.includes('fetch('));
-    assert.ok(html.includes('fuelPriceNotice'));
-    assert.ok(html.includes('fuel prices and currency in'));
-    assert.ok(html.includes('fuelPrice.json'));
+    assert.ok(html.includes('ng-model="liquidFuelPriceValue"'));
+    assert.ok(html.includes('ng-model="electricityPriceValue"'));
+    assert.ok(html.includes('ng-model="currency"'));
     assert.ok(!html.includes('<script type="text/javascript">'));
     assert.ok(html.includes('{{ costPrice }}'));
     assert.ok(html.includes('{{ avgCost }}'));
@@ -74,29 +73,6 @@ describe('UI template styling', () => {
     assert.ok(html.includes('Electric: {{ tripTotalCostElectric }}'));
     assert.ok(html.includes('Liquid: {{ tripFuelUsedLiquid }}'));
     assert.ok(html.includes('Electric: {{ tripFuelUsedElectric }}'));
-  });
-
-  it('toggles fuel price help dialog via controller functions', async () => {
-    let directiveDef;
-    global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };
-    global.StreamsManager = { add: () => {}, remove: () => {} };
-    global.UiUnits = { buildString: () => '' };
-    global.bngApi = { engineLua: () => '' };
-    global.localStorage = { getItem: () => null, setItem: () => {} };
-    global.performance = { now: () => 0 };
-    const $http = { get: () => Promise.resolve({ data: {} }) };
-
-    delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
-    require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
-    const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
-    const $scope = { $on: () => {} };
-    controllerFn({ debug: () => {} }, $scope, $http);
-
-    assert.equal($scope.fuelPriceHelpOpen, false);
-    $scope.openFuelPriceHelp({ preventDefault() {} });
-    assert.equal($scope.fuelPriceHelpOpen, true);
-    $scope.closeFuelPriceHelp();
-    assert.equal($scope.fuelPriceHelpOpen, false);
   });
 
   it('exposes fuel prices and currency in fuelPrice.json', () => {
@@ -116,18 +92,196 @@ describe('UI template styling', () => {
     global.bngApi = { engineLua: () => '' };
     global.localStorage = { getItem: () => null, setItem: () => {} };
     global.performance = { now: () => 0 };
-    const $http = { get: () => Promise.resolve({ data: { liquidFuelPrice: 2.25, electricityPrice: 0.5, currency: 'CZK' } }) };
+
+    const tmp = fs.mkdtempSync(path.join(require('os').tmpdir(), 'fuel-'));
+    process.env.KRTEKTM_BNG_USER_DIR = tmp;
+    const verDir = path.join(tmp, '0.99', 'settings', 'krtektm_fuelEconomy');
+    fs.mkdirSync(verDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(verDir, 'fuelPrice.json'),
+      JSON.stringify({ liquidFuelPrice: 2.25, electricityPrice: 0.5, currency: 'CZK' })
+    );
 
     delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: () => {} };
-    controllerFn({ debug: () => {} }, $scope, $http);
+    controllerFn({ debug: () => {} }, $scope);
     await new Promise(resolve => setImmediate(resolve));
 
     assert.strictEqual($scope.liquidFuelPriceValue, 2.25);
     assert.strictEqual($scope.electricityPriceValue, 0.5);
     assert.strictEqual($scope.currency, 'CZK');
+
+    delete process.env.KRTEKTM_BNG_USER_DIR;
+  });
+
+  it('updates fuel prices when fuelPrice.json changes', async () => {
+    let directiveDef;
+    global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };
+    global.StreamsManager = { add: () => {}, remove: () => {} };
+    global.UiUnits = { buildString: () => '' };
+    global.bngApi = { engineLua: () => '' };
+    global.localStorage = { getItem: () => null, setItem: () => {} };
+    global.performance = { now: () => 0 };
+
+    const tmp = fs.mkdtempSync(path.join(require('os').tmpdir(), 'fuel-'));
+    process.env.KRTEKTM_BNG_USER_DIR = tmp;
+    process.env.KRTEKTM_FUEL_POLL_MS = '20';
+    const verDir = path.join(tmp, '0.98', 'settings', 'krtektm_fuelEconomy');
+    fs.mkdirSync(verDir, { recursive: true });
+    const cfgPath = path.join(verDir, 'fuelPrice.json');
+    fs.writeFileSync(cfgPath, JSON.stringify({ liquidFuelPrice: 1, electricityPrice: 0.2, currency: 'USD' }));
+
+    delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
+    require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+    const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
+    const $scope = { $on: () => {}, $evalAsync: fn => fn() };
+    controllerFn({ debug: () => {} }, $scope);
+    await new Promise(r => setImmediate(r));
+
+    assert.strictEqual($scope.liquidFuelPriceValue, 1);
+    assert.strictEqual($scope.electricityPriceValue, 0.2);
+    assert.strictEqual($scope.currency, 'USD');
+
+    fs.writeFileSync(cfgPath, JSON.stringify({ liquidFuelPrice: 3, electricityPrice: 0.8, currency: 'EUR' }));
+    await new Promise(r => setTimeout(r, 60));
+    assert.strictEqual($scope.liquidFuelPriceValue, 3);
+    assert.strictEqual($scope.electricityPriceValue, 0.8);
+    assert.strictEqual($scope.currency, 'EUR');
+
+    fs.writeFileSync(cfgPath, '{broken');
+    await new Promise(r => setTimeout(r, 60));
+    assert.strictEqual($scope.liquidFuelPriceValue, 0);
+    assert.strictEqual($scope.electricityPriceValue, 0);
+    assert.strictEqual($scope.currency, 'money');
+
+    delete process.env.KRTEKTM_BNG_USER_DIR;
+    delete process.env.KRTEKTM_FUEL_POLL_MS;
+  });
+
+  it('saves fuel prices via saveSettings', async () => {
+    let directiveDef;
+    global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };
+    global.StreamsManager = { add: () => {}, remove: () => {} };
+    global.UiUnits = { buildString: () => '' };
+    global.bngApi = { engineLua: () => '' };
+    global.localStorage = { getItem: () => null, setItem: () => {} };
+    global.performance = { now: () => 0 };
+
+    const tmp = fs.mkdtempSync(path.join(require('os').tmpdir(), 'fuel-'));
+    process.env.KRTEKTM_BNG_USER_DIR = tmp;
+    const verDir = path.join(tmp, '1.01', 'settings', 'krtektm_fuelEconomy');
+    fs.mkdirSync(verDir, { recursive: true });
+
+    delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
+    require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+    const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
+    const $scope = { $on: () => {}, $evalAsync: fn => fn() };
+    controllerFn({ debug: () => {} }, $scope);
+    await new Promise(resolve => setImmediate(resolve));
+
+    $scope.liquidFuelPriceValue = 7.5;
+    $scope.electricityPriceValue = 2.3;
+    $scope.currency = 'GBP';
+    $scope.saveSettings();
+
+    const cfgPath = path.join(verDir, 'fuelPrice.json');
+    const saved = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+    assert.strictEqual(saved.liquidFuelPrice, 7.5);
+    assert.strictEqual(saved.electricityPrice, 2.3);
+    assert.strictEqual(saved.currency, 'GBP');
+
+    delete process.env.KRTEKTM_BNG_USER_DIR;
+  });
+
+  it('loads fuel prices via bngApi.engineLua when require is unavailable', async () => {
+    let directiveDef;
+    global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };
+    global.StreamsManager = { add: () => {}, remove: () => {} };
+    global.UiUnits = { buildString: () => '' };
+    const tmp = fs.mkdtempSync(path.join(require('os').tmpdir(), 'fuel-'));
+    const cfgPath = path.join(tmp, 'settings', 'krtektm_fuelEconomy', 'fuelPrice.json');
+    fs.mkdirSync(path.dirname(cfgPath), { recursive: true });
+    fs.writeFileSync(cfgPath, JSON.stringify({ liquidFuelPrice: 4, electricityPrice: 1.2, currency: 'Kč' }));
+
+    global.bngApi = {
+      engineLua: (code, cb) => {
+        assert.ok(code.startsWith('(function()'), 'Lua chunk should be wrapped in a function');
+        assert.ok(code.includes('core_paths.getUserPath'));
+        try {
+          cb(fs.readFileSync(cfgPath, 'utf8'));
+        } catch (e) {
+          cb(JSON.stringify({ liquidFuelPrice: 0, electricityPrice: 0, currency: 'money' }));
+        }
+      }
+    };
+    global.localStorage = { getItem: () => null, setItem: () => {} };
+    global.performance = { now: () => 0 };
+    const realProcess = global.process;
+    const realSetInterval = global.setInterval;
+    global.process = undefined;
+    global.setInterval = (fn, ms) => realSetInterval(fn, 20);
+
+    delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
+    require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+    const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
+    const $scope = { $on: () => {}, $evalAsync: fn => fn() };
+    controllerFn({ debug: () => {} }, $scope);
+    await new Promise(r => setImmediate(r));
+
+    assert.strictEqual($scope.liquidFuelPriceValue, 4);
+    assert.strictEqual($scope.electricityPriceValue, 1.2);
+    assert.strictEqual($scope.currency, 'Kč');
+
+    fs.writeFileSync(cfgPath, JSON.stringify({ liquidFuelPrice: 5, electricityPrice: 1.5, currency: '€' }));
+    await new Promise(r => setTimeout(r, 60));
+    assert.strictEqual($scope.liquidFuelPriceValue, 5);
+    assert.strictEqual($scope.electricityPriceValue, 1.5);
+    assert.strictEqual($scope.currency, '€');
+
+    fs.writeFileSync(cfgPath, '{bad');
+    await new Promise(r => setTimeout(r, 60));
+    assert.strictEqual($scope.liquidFuelPriceValue, 0);
+    assert.strictEqual($scope.electricityPriceValue, 0);
+    assert.strictEqual($scope.currency, 'money');
+
+    global.process = realProcess;
+    global.setInterval = realSetInterval;
+  });
+
+  it('saves fuel prices via bngApi.engineLua when require is unavailable', async () => {
+    let directiveDef;
+    global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };
+    global.StreamsManager = { add: () => {}, remove: () => {} };
+    global.UiUnits = { buildString: () => '' };
+    const calls = [];
+    global.bngApi = { engineLua: code => { calls.push(code); } };
+    global.localStorage = { getItem: () => null, setItem: () => {} };
+    global.performance = { now: () => 0 };
+    const realProcess = global.process;
+    global.process = undefined;
+
+    delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
+    require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+    const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
+    const $scope = { $on: () => {}, $evalAsync: fn => fn() };
+    controllerFn({ debug: () => {} }, $scope);
+    await new Promise(r => setImmediate(r));
+
+    $scope.liquidFuelPriceValue = 9;
+    $scope.electricityPriceValue = 1.1;
+    $scope.currency = 'JPY';
+    $scope.saveSettings();
+
+      assert.ok(calls.length > 0);
+      const lua = calls[calls.length - 1];
+      assert.ok(lua.includes('fuelPrice.json'));
+      assert.ok(lua.includes('jsonWriteFile'));
+      assert.ok(lua.includes('\\"liquidFuelPrice\\":9'));
+      assert.ok(lua.includes('\\"currency\\":\\"JPY\\"'));
+
+    global.process = realProcess;
   });
 
   it('defaults fuel price when fuelPrice.json is missing', async () => {
@@ -139,13 +293,16 @@ describe('UI template styling', () => {
     global.localStorage = { getItem: () => null, setItem: () => {} };
     let now = 0;
     global.performance = { now: () => now };
-    const $http = { get: () => Promise.reject(new Error('missing')) };
+
+    const tmp = fs.mkdtempSync(path.join(require('os').tmpdir(), 'fuel-'));
+    process.env.KRTEKTM_BNG_USER_DIR = tmp;
+    fs.mkdirSync(path.join(tmp, '0.50'), { recursive: true });
 
     delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, $http);
+    controllerFn({ debug: () => {} }, $scope);
     await new Promise(resolve => setImmediate(resolve));
 
     const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 200, trip: 0, throttle_input: 0.5, rpmTacho: 1000 } };
@@ -166,6 +323,12 @@ describe('UI template styling', () => {
     assert.strictEqual($scope.tripAvgCostElectric, '0.00 money/km');
     assert.strictEqual($scope.tripTotalCostLiquid, '0.00 money');
     assert.strictEqual($scope.tripTotalCostElectric, '0.00 money');
+
+    const cfgPath = path.join(tmp, '0.50', 'settings', 'krtektm_fuelEconomy', 'fuelPrice.json');
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+    assert.strictEqual(cfg.liquidFuelPrice, 0);
+
+    delete process.env.KRTEKTM_BNG_USER_DIR;
   });
 
   it('positions reset, style toggle and settings icons consistently', () => {
@@ -244,7 +407,7 @@ describe('controller integration', () => {
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: () => {}, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, httpStub);
+    controllerFn({ debug: () => {} }, $scope);
 
     assert.strictEqual($scope.visible.costPrice, false);
     assert.strictEqual($scope.visible.avgCost, false);
@@ -262,13 +425,20 @@ describe('controller integration', () => {
     global.localStorage = { getItem: () => null, setItem: () => {} };
     let now = 0;
     global.performance = { now: () => now };
-    const $http = { get: () => Promise.resolve({ data: { liquidFuelPrice: 1.5, electricityPrice: 0.5, currency: 'USD' } }) };
+    const tmp = fs.mkdtempSync(path.join(require('os').tmpdir(), 'fuel-'));
+    process.env.KRTEKTM_BNG_USER_DIR = tmp;
+    const verDir = path.join(tmp, '1.00', 'settings', 'krtektm_fuelEconomy');
+    fs.mkdirSync(verDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(verDir, 'fuelPrice.json'),
+      JSON.stringify({ liquidFuelPrice: 1.5, electricityPrice: 0.5, currency: 'USD' })
+    );
 
     delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, $http);
+    controllerFn({ debug: () => {} }, $scope);
     await new Promise(resolve => setImmediate(resolve));
 
     const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 200, trip: 0, throttle_input: 0.5, rpmTacho: 1000 } };
@@ -325,6 +495,8 @@ describe('controller integration', () => {
     assert.ok(Math.abs(parseFloat($scope.totalCost) - parseFloat($scope.fuelUsed) * 1.5) < 1e-6);
     assert.ok(Math.abs(parseFloat($scope.tripTotalCostLiquid) - parseFloat($scope.tripFuelUsedLiquid) * 1.5) < 1e-6);
     assert.ok(Math.abs(parseFloat($scope.tripTotalCostElectric) - parseFloat($scope.tripFuelUsedElectric) * 0.5) < 1e-6);
+
+    delete process.env.KRTEKTM_BNG_USER_DIR;
   });
 
   it('keeps trip average cost steady while stationary', async () => {
@@ -336,13 +508,20 @@ describe('controller integration', () => {
     global.localStorage = { getItem: () => null, setItem: () => {} };
     let now = 0;
     global.performance = { now: () => now };
-    const $http = { get: () => Promise.resolve({ data: { liquidFuelPrice: 1.5, electricityPrice: 0.5, currency: 'USD' } }) };
+    const tmp = fs.mkdtempSync(path.join(require('os').tmpdir(), 'fuel-'));
+    process.env.KRTEKTM_BNG_USER_DIR = tmp;
+    const verDir = path.join(tmp, '1.01', 'settings', 'krtektm_fuelEconomy');
+    fs.mkdirSync(verDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(verDir, 'fuelPrice.json'),
+      JSON.stringify({ liquidFuelPrice: 1.5, electricityPrice: 0.5, currency: 'USD' })
+    );
 
     delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, $http);
+    controllerFn({ debug: () => {} }, $scope);
     await new Promise(resolve => setImmediate(resolve));
 
     const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 200, trip: 0, throttle_input: 0.5, rpmTacho: 1000 } };
@@ -361,6 +540,8 @@ describe('controller integration', () => {
 
     assert.strictEqual($scope.tripAvgCostLiquid, '0.08 USD/km');
     assert.strictEqual($scope.tripAvgCostElectric, '0.03 USD/km');
+
+    delete process.env.KRTEKTM_BNG_USER_DIR;
   });
 
   it('subtracts electric trip cost when regenerating', async () => {
@@ -372,13 +553,20 @@ describe('controller integration', () => {
     global.localStorage = { getItem: () => null, setItem: () => {} };
     let now = 0;
     global.performance = { now: () => now };
-    const $http = { get: () => Promise.resolve({ data: { liquidFuelPrice: 1.5, electricityPrice: 0.5, currency: 'USD' } }) };
+    const tmp = fs.mkdtempSync(path.join(require('os').tmpdir(), 'fuel-'));
+    process.env.KRTEKTM_BNG_USER_DIR = tmp;
+    const verDir = path.join(tmp, '1.02', 'settings', 'krtektm_fuelEconomy');
+    fs.mkdirSync(verDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(verDir, 'fuelPrice.json'),
+      JSON.stringify({ liquidFuelPrice: 1.5, electricityPrice: 0.5, currency: 'USD' })
+    );
 
     delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, $http);
+    controllerFn({ debug: () => {} }, $scope);
     await new Promise(resolve => setImmediate(resolve));
 
     $scope.setUnit('electric');
@@ -404,6 +592,8 @@ describe('controller integration', () => {
     assert.strictEqual($scope.tripFuelUsedElectric, '1.00 kWh');
     assert.strictEqual($scope.tripFuelUsedLiquid, '0.00 L');
     assert.ok(Math.abs(parseFloat($scope.tripTotalCostElectric) - parseFloat($scope.tripFuelUsedElectric) * 0.5) < 1e-6);
+
+    delete process.env.KRTEKTM_BNG_USER_DIR;
   });
 
   it('tracks trip fuel usage for total cost', async () => {
@@ -419,13 +609,20 @@ describe('controller integration', () => {
     global.localStorage = { getItem: k => (k in store ? store[k] : null), setItem: (k, v) => { store[k] = v; } };
     let now = 0;
     global.performance = { now: () => now };
-    const $http = { get: () => Promise.resolve({ data: { liquidFuelPrice: 1.5, electricityPrice: 0, currency: 'USD' } }) };
+    const tmp = fs.mkdtempSync(path.join(require('os').tmpdir(), 'fuel-'));
+    process.env.KRTEKTM_BNG_USER_DIR = tmp;
+    const verDir = path.join(tmp, '1.03', 'settings', 'krtektm_fuelEconomy');
+    fs.mkdirSync(verDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(verDir, 'fuelPrice.json'),
+      JSON.stringify({ liquidFuelPrice: 1.5, electricityPrice: 0, currency: 'USD' })
+    );
 
     delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, $http);
+    controllerFn({ debug: () => {} }, $scope);
     await new Promise(resolve => setImmediate(resolve));
 
     const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 200, trip: 0, throttle_input: 0.5, rpmTacho: 1000 } };
@@ -453,6 +650,8 @@ describe('controller integration', () => {
     assert.strictEqual($scope.tripTotalCostElectric, '');
     assert.strictEqual($scope.tripFuelUsedLiquid, '');
     assert.strictEqual($scope.tripFuelUsedElectric, '');
+
+    delete process.env.KRTEKTM_BNG_USER_DIR;
   });
 
   it('retains trip total cost across vehicle changes', async () => {
@@ -468,13 +667,20 @@ describe('controller integration', () => {
     global.localStorage = { getItem: k => (k in store ? store[k] : null), setItem: (k, v) => { store[k] = v; } };
     let now = 0;
     global.performance = { now: () => now };
-    const $http = { get: () => Promise.resolve({ data: { liquidFuelPrice: 1.5, electricityPrice: 0, currency: 'USD' } }) };
+    const tmp = fs.mkdtempSync(path.join(require('os').tmpdir(), 'fuel-'));
+    process.env.KRTEKTM_BNG_USER_DIR = tmp;
+    const verDir = path.join(tmp, '1.04', 'settings', 'krtektm_fuelEconomy');
+    fs.mkdirSync(verDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(verDir, 'fuelPrice.json'),
+      JSON.stringify({ liquidFuelPrice: 1.5, electricityPrice: 0, currency: 'USD' })
+    );
 
     delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, $http);
+    controllerFn({ debug: () => {} }, $scope);
     await new Promise(resolve => setImmediate(resolve));
 
     const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 200, trip: 0, throttle_input: 0.5, rpmTacho: 1000 } };
@@ -518,6 +724,8 @@ describe('controller integration', () => {
 
     const stored = JSON.parse(store.okFuelEconomyOverall);
     assert.ok(Math.abs(stored.fuelUsedLiquid - 3) < 1e-6);
+
+    delete process.env.KRTEKTM_BNG_USER_DIR;
   });
 
   it('restores trip totals after controller reload', async () => {
@@ -533,7 +741,14 @@ describe('controller integration', () => {
     global.localStorage = { getItem: k => (k in store ? store[k] : null), setItem: (k, v) => { store[k] = v; } };
     let now = 0;
     global.performance = { now: () => now };
-    const $http = { get: () => Promise.resolve({ data: { liquidFuelPrice: 1.5, electricityPrice: 0, currency: 'USD' } }) };
+    const tmp = fs.mkdtempSync(path.join(require('os').tmpdir(), 'fuel-'));
+    process.env.KRTEKTM_BNG_USER_DIR = tmp;
+    const verDir = path.join(tmp, '1.05', 'settings', 'krtektm_fuelEconomy');
+    fs.mkdirSync(verDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(verDir, 'fuelPrice.json'),
+      JSON.stringify({ liquidFuelPrice: 1.5, electricityPrice: 0, currency: 'USD' })
+    );
 
     function loadController() {
       let def;
@@ -545,7 +760,7 @@ describe('controller integration', () => {
       require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
       const ctrl = def.controller[def.controller.length - 1];
       const scope = { $on: (name, cb) => { scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-      ctrl({ debug: () => {} }, scope, $http);
+      ctrl({ debug: () => {} }, scope);
       return scope;
     }
 
@@ -580,6 +795,8 @@ describe('controller integration', () => {
     stored = JSON.parse(store.okFuelEconomyOverall);
     assert.strictEqual(stored.tripCostLiquid, 4.5);
     assert.ok(Math.abs(stored.fuelUsedLiquid - 3) < 1e-6);
+
+    delete process.env.KRTEKTM_BNG_USER_DIR;
   });
 
   it('avoids spurious tank drop when engine shuts off', async () => {
@@ -595,13 +812,20 @@ describe('controller integration', () => {
     global.localStorage = { getItem: k => (k in store ? store[k] : null), setItem: (k, v) => { store[k] = v; } };
     let now = 0;
     global.performance = { now: () => now };
-    const $http = { get: () => Promise.resolve({ data: { liquidFuelPrice: 32.5, electricityPrice: 0, currency: 'money' } }) };
+    const tmp = fs.mkdtempSync(path.join(require('os').tmpdir(), 'fuel-'));
+    process.env.KRTEKTM_BNG_USER_DIR = tmp;
+    const verDir = path.join(tmp, '1.06', 'settings', 'krtektm_fuelEconomy');
+    fs.mkdirSync(verDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(verDir, 'fuelPrice.json'),
+      JSON.stringify({ liquidFuelPrice: 32.5, electricityPrice: 0, currency: 'money' })
+    );
 
     delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, $http);
+    controllerFn({ debug: () => {} }, $scope);
     await new Promise(resolve => setImmediate(resolve));
 
     const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 0, trip: 0, throttle_input: 0.5, rpmTacho: 1000 } };
@@ -632,6 +856,8 @@ describe('controller integration', () => {
 
     assert.strictEqual($scope.tripTotalCostLiquid, '32.50 money');
     assert.strictEqual($scope.tripTotalCostElectric, '0.00 money');
+
+    delete process.env.KRTEKTM_BNG_USER_DIR;
   });
 
   it('shows zero instant consumption when fuel flow stops but engine keeps spinning', () => {
@@ -648,7 +874,7 @@ describe('controller integration', () => {
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, httpStub);
+    controllerFn({ debug: () => {} }, $scope);
 
     const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 10, trip: 0, throttle_input: 0.5, rpmTacho: 1000 } };
     streams.engineInfo[11] = 50;
@@ -684,7 +910,7 @@ describe('controller integration', () => {
       $on: (name, cb) => { $scope['on_' + name] = cb; },
       $evalAsync: fn => fn()
     };
-    controllerFn({ debug: () => {} }, $scope, httpStub);
+    controllerFn({ debug: () => {} }, $scope);
 
     const streams = {
       engineInfo: Array(15).fill(0),
@@ -721,7 +947,7 @@ describe('controller integration', () => {
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, httpStub);
+    controllerFn({ debug: () => {} }, $scope);
 
     const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 0, trip: 0, throttle_input: 0, rpmTacho: 0 } };
     streams.engineInfo[11] = 50; streams.engineInfo[12] = 60;
@@ -760,7 +986,7 @@ describe('controller integration', () => {
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, httpStub);
+    controllerFn({ debug: () => {} }, $scope);
 
     const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 0, airspeed: 0, throttle_input: 0, rpmTacho: 0, trip: 0 } };
     streams.engineInfo[11] = 50;
@@ -784,7 +1010,7 @@ describe('controller integration', () => {
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, httpStub);
+    controllerFn({ debug: () => {} }, $scope);
 
     const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 20, trip: 0, throttle_input: 0, rpmTacho: 1000 } };
     streams.engineInfo[11] = 50;
@@ -816,7 +1042,7 @@ describe('controller integration', () => {
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, httpStub);
+    controllerFn({ debug: () => {} }, $scope);
 
     const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 10, trip: 5, throttle_input: 0 } };
     streams.engineInfo[11] = 50;
@@ -849,7 +1075,7 @@ describe('controller integration', () => {
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, httpStub);
+    controllerFn({ debug: () => {} }, $scope);
 
     const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 10, airspeed: 10, throttle_input: 0.5, rpmTacho: 1000, trip: 0 } };
     streams.engineInfo[11] = 50;
@@ -892,7 +1118,7 @@ describe('controller integration', () => {
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, httpStub);
+    controllerFn({ debug: () => {} }, $scope);
 
     const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 10, airspeed: 10, throttle_input: 0.5, rpmTacho: 1000, trip: 0 } };
     streams.engineInfo[11] = 50;
@@ -935,7 +1161,7 @@ describe('controller integration', () => {
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, httpStub);
+    controllerFn({ debug: () => {} }, $scope);
 
     const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 10, airspeed: 10, throttle_input: 0.5, rpmTacho: 1000, trip: 0 } };
     streams.engineInfo[11] = 50;
@@ -977,7 +1203,7 @@ describe('controller integration', () => {
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, httpStub);
+    controllerFn({ debug: () => {} }, $scope);
 
     const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 10, airspeed: 10, throttle_input: 0.5, rpmTacho: 1000, trip: 0 } };
     streams.engineInfo[11] = 50;
@@ -1012,7 +1238,7 @@ describe('controller integration', () => {
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, httpStub);
+    controllerFn({ debug: () => {} }, $scope);
 
     const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 10, airspeed: 10, throttle_input: 0.5, rpmTacho: 1000, trip: 0 } };
     streams.engineInfo[11] = 50;
@@ -1064,7 +1290,7 @@ describe('controller integration', () => {
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, httpStub);
+    controllerFn({ debug: () => {} }, $scope);
 
     const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 0, airspeed: 0, throttle_input: 0, rpmTacho: 0, trip: 0 } };
     streams.engineInfo[11] = 50;
@@ -1097,7 +1323,7 @@ describe('controller integration', () => {
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
-    controllerFn({ debug: () => {} }, $scope, httpStub);
+    controllerFn({ debug: () => {} }, $scope);
 
     const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 0, airspeed: 0, throttle_input: 0, rpmTacho: 0, trip: 0 } };
     streams.engineInfo[11] = 50;
@@ -1148,7 +1374,7 @@ describe('visibility settings persistence', () => {
     const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
 
     const $scope = { $on: () => {} };
-    controllerFn({ debug: () => {} }, $scope, httpStub);
+    controllerFn({ debug: () => {} }, $scope);
 
     assert.equal($scope.visible.heading, true);
     $scope.visible.heading = false;
@@ -1163,7 +1389,7 @@ describe('visibility settings persistence', () => {
     assert.ok(store.okFuelEconomyVisible.includes('"instantGraph":false'));
 
     const $scope2 = { $on: () => {} };
-    controllerFn({ debug: () => {} }, $scope2, httpStub);
+    controllerFn({ debug: () => {} }, $scope2);
     assert.equal($scope2.visible.heading, false);
     assert.equal($scope2.visible.fuelLeft, false);
     assert.equal($scope2.visible.instantLph, false);


### PR DESCRIPTION
## Summary
- add inputs and Save action to adjust liquid and electric fuel prices and currency from the UI
- persist fuel price changes to the latest BeamNG user settings folder or via `bngApi.engineLua`
- document in-game fuel price editing and add tests for saving via Node and engineLua

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b60c08f2308329b18825d6dd6e0664