### PR TITLE
feat: edit fuel prices from the UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Data are gathered via `StreamsManager` from the *electrics* and *engineInfo* cha
 
 ## Fuel price configuration
 
-To enable fuel cost calculations, edit `AppData/Local/BeamNG.drive/{version}/settings/krtektm_fuelEconomy/fuelPrice.json` (for example `C:/Users/<your user>/AppData/Local/BeamNG.drive/<version>/settings/krtektm_fuelEconomy/fuelPrice.json` on Windows) and set the `liquidFuelPrice` and `electricityPrice` values to the prices of fuel per volume unit you use and optionally set the `currency` label (e.g. `$`, `€`). The controller loads these values at runtime and computes average cost per distance, trip average cost per distance, total fuel cost and trip total fuel cost when the relevant fields are enabled in settings.
+To enable fuel cost calculations, set the fuel prices and currency in the app's settings dialog. The inputs store prices in `AppData/Local/BeamNG.drive/{version}/settings/krtektm_fuelEconomy/fuelPrice.json` (for example `C:/Users/<your user>/AppData/Local/BeamNG.drive/<version>/settings/krtektm_fuelEconomy/fuelPrice.json` on Windows). You can also edit this file manually. The controller loads these values at runtime and computes average cost per distance, trip average cost per distance, total fuel cost and trip total fuel cost when the relevant fields are enabled in settings.
 Trip costs accumulate only while their respective unit mode is active: liquid costs grow when using metric or imperial units, whereas electric costs grow when using the electric unit mode.
-Any edits to this file while the game is running are picked up automatically so prices can be changed without restarting.
+Any edits to this file or changes made via the settings dialog while the game is running are picked up automatically so prices can be changed without restarting.
 If the file is missing, the widget falls back to a price of `0` and a currency label of `money` so the calculator still operates.
 
 ## Tests

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -286,26 +286,18 @@
       <label><input type="checkbox" ng-model="visible.totalCost"> Total fuel cost</label><br>
       <label><input type="checkbox" ng-model="visible.tripAvgCost"> Trip average fuel cost per {{ unitDistanceUnit }}</label><br>
       <label><input type="checkbox" ng-model="visible.tripTotalCost"> Trip total fuel cost</label><br>
-      <p id="fuelPriceNotice"
-         ng-attr-style="{{ 'margin:4px 0;' + (useCustomStyles ? ' color:#aeeaff;' : '') }}">
-        Set fuel prices and currency in
-        <a href=""
-           ng-click="openFuelPriceHelp($event)"
-           ng-attr-style="{{ useCustomStyles ? ' color:#aeeaff;' : '' }}">fuelPrice.json</a>
-      </p>
-      <div ng-if="fuelPriceHelpOpen"
-           ng-attr-style="{{ 'position:absolute; top:68px; right:4px; z-index:10; padding:8px; border-radius:6px; background:rgba(0,0,0,0.85); max-width:260px;' + (useCustomStyles ? ' color:#aeeaff; border:1px solid #5fdcff;' : ' color:#fff; border:1px solid #ccc; background:#333;') }}">
-        <p ng-attr-style="{{ 'margin:0 0 8px;' + (useCustomStyles ? '' : '') }}">
-          To enable fuel cost calculations, edit
-          <strong>AppData/<wbr>Local/<wbr>BeamNG.drive/<wbr>{version}/<wbr>settings/<wbr>krtektm_fuelEconomy/<wbr>fuelPrice.json</strong>
-          and set the <strong>liquidFuelPrice</strong> and <strong>electricityPrice</strong> values to the prices of fuel per volume unit you use
-          and optionally set the <strong>currency</strong> label (e.g. <strong>$</strong>, <strong>€</strong>).
-          Changes to this file are applied automatically while the app is running.
-        </p>
-        <button type="button"
-                ng-click="closeFuelPriceHelp()"
-                ng-attr-style="{{ 'font-size:0.8em; padding:2px 6px; cursor:pointer;' + (useCustomStyles ? ' color:#aeeaff; background:rgba(0,200,255,0.15); border:1px solid #5fdcff;' : '') }}">OK</button>
-      </div>
+      <label>Liquid fuel price (per {{ unitVolumeUnit }}):
+        <input type="number" step="0.01" ng-model="liquidFuelPriceValue"
+               ng-attr-style="{{ 'margin-left:4px; width:60px;' + (useCustomStyles ? ' background:rgba(0,200,255,0.15); border:1px solid #5fdcff; color:#aeeaff;' : '') }}">
+      </label><br>
+      <label>Electricity price (per kWh):
+        <input type="number" step="0.01" ng-model="electricityPriceValue"
+               ng-attr-style="{{ 'margin-left:4px; width:60px;' + (useCustomStyles ? ' background:rgba(0,200,255,0.15); border:1px solid #5fdcff; color:#aeeaff;' : '') }}">
+      </label><br>
+      <label>Currency:
+        <input type="text" ng-model="currency"
+               ng-attr-style="{{ 'margin-left:4px; width:60px;' + (useCustomStyles ? ' background:rgba(0,200,255,0.15); border:1px solid #5fdcff; color:#aeeaff;' : '') }}">
+      </label><br>
       <div ng-attr-style="{{ 'position:relative;' + (useCustomStyles ? '' : '') }}">
         <label>Units:
           <span ng-click="unitMenuOpen = !unitMenuOpen"


### PR DESCRIPTION
## Summary
- add inputs in settings dialog to edit liquid fuel price, electricity price and currency
- persist new fuel prices to user fuelPrice.json and reload automatically
- document and test in-game fuel price editing

## Testing
- `node --test tests/app.test.js tests/cumulative.test.js tests/regeneration.test.js tests/simulation.test.js tests/tripFuelUsed.test.js tests/ui.test.js`
- `node --test tests/stress.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b624432564832980c0c40402d66be1