### PR TITLE
Pause fuel economy calculations when engine is off

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -308,6 +308,6 @@
               ng-attr-style="{{ 'margin-top:4px; font-size:0.8em; padding:2px 6px; cursor:pointer;' + (useCustomStyles ? ' color:#aeeaff; background:rgba(0,200,255,0.15); border:1px solid #5fdcff;' : '') }}">
         <span class="material-icons" ng-attr-style="{{ 'font-size:inherit; vertical-align:middle; margin-right:2px;' + (useCustomStyles ? '' : '') }}">save</span>Save
       </button>
-      <p ng-attr-style="{{ useCustomStyles ? 'margin-top:4px; color:#aeeaff;' : '' }}">Project version: 1.0.7</p>
+      <p ng-attr-style="{{ useCustomStyles ? 'margin-top:4px; color:#aeeaff;' : '' }}">Project version: 1.0.8</p>
   </div>
 </div>

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -308,6 +308,6 @@
               ng-attr-style="{{ 'margin-top:4px; font-size:0.8em; padding:2px 6px; cursor:pointer;' + (useCustomStyles ? ' color:#aeeaff; background:rgba(0,200,255,0.15); border:1px solid #5fdcff;' : '') }}">
         <span class="material-icons" ng-attr-style="{{ 'font-size:inherit; vertical-align:middle; margin-right:2px;' + (useCustomStyles ? '' : '') }}">save</span>Save
       </button>
-      <p ng-attr-style="{{ useCustomStyles ? 'margin-top:4px; color:#aeeaff;' : '' }}">Project version: 1.0.6</p>
+      <p ng-attr-style="{{ useCustomStyles ? 'margin-top:4px; color:#aeeaff;' : '' }}">Project version: 1.0.7</p>
   </div>
 </div>

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -308,6 +308,6 @@
               ng-attr-style="{{ 'margin-top:4px; font-size:0.8em; padding:2px 6px; cursor:pointer;' + (useCustomStyles ? ' color:#aeeaff; background:rgba(0,200,255,0.15); border:1px solid #5fdcff;' : '') }}">
         <span class="material-icons" ng-attr-style="{{ 'font-size:inherit; vertical-align:middle; margin-right:2px;' + (useCustomStyles ? '' : '') }}">save</span>Save
       </button>
-      <p ng-attr-style="{{ useCustomStyles ? 'margin-top:4px; color:#aeeaff;' : '' }}">Project version: 1.0.5</p>
+      <p ng-attr-style="{{ useCustomStyles ? 'margin-top:4px; color:#aeeaff;' : '' }}">Project version: 1.0.6</p>
   </div>
 </div>

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -308,6 +308,6 @@
               ng-attr-style="{{ 'margin-top:4px; font-size:0.8em; padding:2px 6px; cursor:pointer;' + (useCustomStyles ? ' color:#aeeaff; background:rgba(0,200,255,0.15); border:1px solid #5fdcff;' : '') }}">
         <span class="material-icons" ng-attr-style="{{ 'font-size:inherit; vertical-align:middle; margin-right:2px;' + (useCustomStyles ? '' : '') }}">save</span>Save
       </button>
-      <p ng-attr-style="{{ useCustomStyles ? 'margin-top:4px; color:#aeeaff;' : '' }}">Project version: 1.0.8</p>
+      <p ng-attr-style="{{ useCustomStyles ? 'margin-top:4px; color:#aeeaff;' : '' }}">Project version: 1.0.6</p>
   </div>
 </div>

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -137,6 +137,26 @@ function resolveSpeed(wheelSpeed_mps, airSpeed_mps, EPS_SPEED) {
   return Math.abs(wheelSpeed_mps || 0) > EPS_SPEED ? wheelSpeed_mps : 0;
 }
 
+function isEngineRunning(electrics, engineInfo) {
+  if (electrics) {
+    if (typeof electrics.engineRunning === 'boolean') {
+      return electrics.engineRunning;
+    }
+    if (typeof electrics.ignitionLevel === 'number') {
+      return electrics.ignitionLevel > 1;
+    }
+  }
+  if (
+    Array.isArray(engineInfo) &&
+    typeof engineInfo[14] === 'number' &&
+    engineInfo[14] !== 0
+  ) {
+    return engineInfo[14] > 0;
+  }
+  var rpm = (electrics && electrics.rpmTacho) || 0;
+  return rpm > 0;
+}
+
 function buildQueueGraphPoints(queue, width, height) {
   if (!Array.isArray(queue) || queue.length < 2) return '';
   var max = Math.max.apply(null, queue);
@@ -250,6 +270,7 @@ if (typeof module !== 'undefined') {
     resolveAverageConsumption,
     buildQueueGraphPoints,
     resolveSpeed,
+    isEngineRunning,
     getUnitLabels,
     formatDistance,
     formatVolume,
@@ -793,8 +814,7 @@ angular.module('beamng.apps')
           var currentFuel_l = streams.engineInfo[11];
           var capacity_l = streams.engineInfo[12];
           var throttle = streams.electrics.throttle_input || 0;
-          var rpm = streams.electrics.rpmTacho || 0;
-          var engineRunning = rpm > 0;
+          var engineRunning = isEngineRunning(streams.electrics, streams.engineInfo);
           if (!engineRunning && engineWasRunning) {
             resetInstantHistory();
           }

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -832,35 +832,35 @@ angular.module('beamng.apps')
             distance_m = 0;
           }
 
-          var deltaTripFuel = previousFuel_l - currentFuel_l;
-          if (Math.abs(deltaTripFuel) < capacity_l) {
-            var deltaFuelUnit = convertVolumeToUnit(deltaTripFuel, $scope.unitMode);
-            if ($scope.unitMode === 'electric') {
-              tripFuelUsedElectric_l += deltaTripFuel;
-              overall.fuelUsedElectric = tripFuelUsedElectric_l;
-              tripCostElectric += deltaFuelUnit * $scope.electricityPriceValue;
-            } else {
-              if (deltaTripFuel > 0) {
+          if (engineRunning) {
+            var deltaTripFuel = previousFuel_l - currentFuel_l;
+            if (Math.abs(deltaTripFuel) < capacity_l) {
+              var deltaFuelUnit = convertVolumeToUnit(deltaTripFuel, $scope.unitMode);
+              if ($scope.unitMode === 'electric') {
+                tripFuelUsedElectric_l += deltaTripFuel;
+                overall.fuelUsedElectric = tripFuelUsedElectric_l;
+                tripCostElectric += deltaFuelUnit * $scope.electricityPriceValue;
+              } else if (deltaTripFuel > 0) {
                 tripFuelUsedLiquid_l += deltaTripFuel;
                 overall.fuelUsedLiquid = tripFuelUsedLiquid_l;
                 tripCostLiquid += deltaFuelUnit * $scope.liquidFuelPriceValue;
               }
             }
-          }
-          if (speed_mps > EPS_SPEED) {
-            if ($scope.unitMode === 'electric') {
-              tripDistanceElectric_m += deltaDistance;
-            } else {
-              tripDistanceLiquid_m += deltaDistance;
+            if (speed_mps > EPS_SPEED) {
+              if ($scope.unitMode === 'electric') {
+                tripDistanceElectric_m += deltaDistance;
+              } else {
+                tripDistanceLiquid_m += deltaDistance;
+              }
             }
-          }
-          overall.tripCostLiquid = tripCostLiquid;
-          overall.tripCostElectric = tripCostElectric;
-          overall.tripDistanceLiquid = tripDistanceLiquid_m;
-          overall.tripDistanceElectric = tripDistanceElectric_m;
-          if (now_ms - (overall.lastCostSaveTime || 0) >= 100) {
-            saveOverall();
-            overall.lastCostSaveTime = now_ms;
+            overall.tripCostLiquid = tripCostLiquid;
+            overall.tripCostElectric = tripCostElectric;
+            overall.tripDistanceLiquid = tripDistanceLiquid_m;
+            overall.tripDistanceElectric = tripDistanceElectric_m;
+            if (now_ms - (overall.lastCostSaveTime || 0) >= 100) {
+              saveOverall();
+              overall.lastCostSaveTime = now_ms;
+            }
           }
 
           if (distance_m === 0 && lastDistance_m > 0) {

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -4,6 +4,7 @@
 // extremely small speeds, keeping idle or creeping readings realistic.
 var EPS_SPEED = 0.005; // [m/s]
 var MIN_VALID_SPEED_MPS = 1; // ~3.6 km/h
+var MIN_RPM_RUNNING = 100; // below this rpm the engine is considered off
 
 function calculateFuelFlow(currentFuel, previousFuel, dtSeconds) {
   if (dtSeconds <= 0 || previousFuel === null) return 0;
@@ -154,7 +155,7 @@ function isEngineRunning(electrics, engineInfo) {
     return engineInfo[14] > 0;
   }
   var rpm = (electrics && electrics.rpmTacho) || 0;
-  return rpm > 0;
+  return rpm >= MIN_RPM_RUNNING;
 }
 
 function buildQueueGraphPoints(queue, width, height) {

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
@@ -1,7 +1,7 @@
 {
   "name" : "Fuel Economy",
   "author": "KRtekTM",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Fuel Economy - Average Fuel Consumption",
   "directive": "okFuelEconomy",
   "domElement": "<ok-fuel-economy></ok-fuel-economy>",

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
@@ -1,7 +1,7 @@
 {
   "name" : "Fuel Economy",
   "author": "KRtekTM",
-  "version": "1.0.8",
+  "version": "1.0.6",
   "description": "Fuel Economy - Average Fuel Consumption",
   "directive": "okFuelEconomy",
   "domElement": "<ok-fuel-economy></ok-fuel-economy>",

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
@@ -1,7 +1,7 @@
 {
   "name" : "Fuel Economy",
   "author": "KRtekTM",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Fuel Economy - Average Fuel Consumption",
   "directive": "okFuelEconomy",
   "domElement": "<ok-fuel-economy></ok-fuel-economy>",

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
@@ -1,7 +1,7 @@
 {
   "name" : "Fuel Economy",
   "author": "KRtekTM",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Fuel Economy - Average Fuel Consumption",
   "directive": "okFuelEconomy",
   "domElement": "<ok-fuel-economy></ok-fuel-economy>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beamng-fuel-economy-mod",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "BeamNG fuel economy mod",
   "scripts": {
     "test": "node --test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beamng-fuel-economy-mod",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "BeamNG fuel economy mod",
   "scripts": {
     "test": "node --test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beamng-fuel-economy-mod",
-  "version": "1.0.8",
+  "version": "1.0.6",
   "description": "BeamNG fuel economy mod",
   "scripts": {
     "test": "node --test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beamng-fuel-economy-mod",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "BeamNG fuel economy mod",
   "scripts": {
     "test": "node --test"

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -15,6 +15,7 @@ const {
   buildQueueGraphPoints,
   resolveSpeed,
   resolveAverageConsumption,
+  isEngineRunning,
   formatDistance,
   formatVolume,
   formatConsumptionRate,
@@ -242,6 +243,33 @@ describe('app.js utility functions', () => {
     it('falls back to wheel speed when airspeed missing', () => {
       const s = resolveSpeed(7, undefined, EPS_SPEED);
       assert.strictEqual(s, 7);
+    });
+  });
+
+  describe('isEngineRunning', () => {
+    it('prefers the engineRunning flag when present', () => {
+      assert.strictEqual(
+        isEngineRunning({ engineRunning: false, rpmTacho: 800 }, []),
+        false
+      );
+      assert.strictEqual(
+        isEngineRunning({ engineRunning: true, rpmTacho: 0 }, []),
+        true
+      );
+    });
+    it('falls back to ignition level', () => {
+      assert.strictEqual(
+        isEngineRunning({ ignitionLevel: 0, rpmTacho: 900 }, []),
+        false
+      );
+      assert.strictEqual(
+        isEngineRunning({ ignitionLevel: 2, rpmTacho: 0 }, []),
+        true
+      );
+    });
+    it('uses rpm as a last resort', () => {
+      assert.strictEqual(isEngineRunning({ rpmTacho: 700 }, []), true);
+      assert.strictEqual(isEngineRunning({}, []), false);
     });
   });
 

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -14,6 +14,7 @@ const {
   calculateRange,
   buildQueueGraphPoints,
   resolveSpeed,
+  resolveAverageConsumption,
   formatDistance,
   formatVolume,
   formatConsumptionRate,
@@ -170,6 +171,38 @@ describe('app.js utility functions', () => {
     });
     it('treats negative avg as no consumption while stopped', () => {
       assert.strictEqual(calculateRange(10, -5, 0, EPS_SPEED), 0);
+    });
+  });
+
+  describe('resolveAverageConsumption', () => {
+    it('uses previous averages when engine is off', () => {
+      const avg = resolveAverageConsumption(false, 0, 0, 0, 0, 5, 7);
+      assert.strictEqual(avg, 5);
+    });
+    it('computes average when running and moving', () => {
+      const avg = resolveAverageConsumption(
+        true,
+        MIN_VALID_SPEED_MPS + 1,
+        1,
+        1000,
+        0,
+        0,
+        0
+      );
+      assert.strictEqual(avg, calculateAverageConsumption(1, 1000));
+    });
+    it('falls back to instant rate at low speed', () => {
+      const inst = 8;
+      const avg = resolveAverageConsumption(
+        true,
+        MIN_VALID_SPEED_MPS / 2,
+        0,
+        0,
+        inst,
+        0,
+        0
+      );
+      assert.strictEqual(avg, inst);
     });
   });
 

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -269,6 +269,7 @@ describe('app.js utility functions', () => {
     });
     it('uses rpm as a last resort', () => {
       assert.strictEqual(isEngineRunning({ rpmTacho: 700 }, []), true);
+      assert.strictEqual(isEngineRunning({ rpmTacho: 50 }, []), false);
       assert.strictEqual(isEngineRunning({}, []), false);
     });
   });

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1358,6 +1358,58 @@ describe('controller integration', () => {
     assert.strictEqual($scope.instantHistory, '');
   });
 
+  it('pauses updates when rpm is below threshold without engineRunning flag', () => {
+    let directiveDef;
+    global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };
+    global.StreamsManager = { add: () => {}, remove: () => {} };
+    global.UiUnits = { buildString: () => '' };
+    global.bngApi = { engineLua: () => '' };
+    const store = {
+      okFuelEconomyOverall: JSON.stringify({ queue: [], distance: 0, previousAvg: 0, previousAvgTrip: 0, fuelUsedLiquid: 0, fuelUsedElectric: 0 }),
+      okFuelEconomyAvgHistory: JSON.stringify({ queue: [] })
+    };
+    global.localStorage = { getItem: k => (k in store ? store[k] : null), setItem: (k,v) => { store[k] = v; } };
+    let now = 0;
+    global.performance = { now: () => now };
+
+    delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
+    require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+    const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
+    const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
+    controllerFn({ debug: () => {} }, $scope);
+
+    const streams = {
+      engineInfo: Array(15).fill(0),
+      electrics: { wheelspeed: 10, throttle_input: 0.5, rpmTacho: 1000, trip: 0 }
+    };
+    streams.engineInfo[11] = 60;
+    streams.engineInfo[12] = 80;
+
+    for (let i = 0; i < 3; i++) {
+      now += 1000;
+      streams.engineInfo[11] -= 0.1;
+      $scope.on_streamsUpdate(null, streams);
+    }
+
+    const avgHist = $scope.avgHistory;
+    const tripHist = $scope.tripAvgHistory;
+    const tripCost = $scope.tripAvgCostLiquid;
+
+    streams.electrics.rpmTacho = 50;
+    streams.electrics.throttle_input = 0;
+    streams.electrics.wheelspeed = 0;
+
+    for (let i = 0; i < 5; i++) {
+      now += 1000;
+      $scope.on_streamsUpdate(null, streams);
+    }
+
+    assert.strictEqual($scope.avgHistory, avgHist);
+    assert.strictEqual($scope.tripAvgHistory, tripHist);
+    assert.strictEqual($scope.tripAvgCostLiquid, tripCost);
+    assert.strictEqual($scope.instantHistory, '');
+  });
+
   it('ignores unrealistic consumption spikes while stationary', () => {
     let directiveDef;
     global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1290,10 +1290,11 @@ describe('controller integration', () => {
 
     streams.electrics.rpmTacho = 0;
     streams.electrics.throttle_input = 0;
-    streams.electrics.wheelspeed = 0;
+    streams.electrics.wheelspeed = 5;
 
     for (let i = 0; i < 5; i++) {
       now += 1000;
+      streams.engineInfo[11] -= 0.05;
       $scope.on_streamsUpdate(null, streams);
     }
 

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -993,7 +993,7 @@ describe('controller integration', () => {
     const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
     controllerFn({ debug: () => {} }, $scope);
 
-    const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 10, trip: 5, throttle_input: 0 } };
+    const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 10, trip: 5, throttle_input: 0, rpmTacho: 1000 } };
     streams.engineInfo[11] = 50;
     streams.engineInfo[12] = 60;
 
@@ -1251,6 +1251,55 @@ describe('controller integration', () => {
 
     assert.strictEqual($scope.tripAvgHistory, '');
     assert.strictEqual($scope.avgHistory, '');
+    assert.strictEqual($scope.instantHistory, '');
+  });
+
+  it('pauses history and cost updates when the engine is off', () => {
+    let directiveDef;
+    global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };
+    global.StreamsManager = { add: () => {}, remove: () => {} };
+    global.UiUnits = { buildString: () => '' };
+    global.bngApi = { engineLua: () => '' };
+    const store = {
+      okFuelEconomyOverall: JSON.stringify({ queue: [], distance: 0, previousAvg: 0, previousAvgTrip: 0, fuelUsedLiquid: 0, fuelUsedElectric: 0 }),
+      okFuelEconomyAvgHistory: JSON.stringify({ queue: [] })
+    };
+    global.localStorage = { getItem: k => (k in store ? store[k] : null), setItem: (k,v) => { store[k] = v; } };
+    let now = 0;
+    global.performance = { now: () => now };
+
+    delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
+    require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+    const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
+    const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
+    controllerFn({ debug: () => {} }, $scope);
+
+    const streams = { engineInfo: Array(15).fill(0), electrics: { wheelspeed: 10, throttle_input: 0.5, rpmTacho: 1000, trip: 0 } };
+    streams.engineInfo[11] = 60;
+    streams.engineInfo[12] = 80;
+
+    for (let i = 0; i < 3; i++) {
+      now += 1000;
+      streams.engineInfo[11] -= 0.1;
+      $scope.on_streamsUpdate(null, streams);
+    }
+
+    const avgHist = $scope.avgHistory;
+    const tripHist = $scope.tripAvgHistory;
+    const tripCost = $scope.tripAvgCostLiquid;
+
+    streams.electrics.rpmTacho = 0;
+    streams.electrics.throttle_input = 0;
+    streams.electrics.wheelspeed = 0;
+
+    for (let i = 0; i < 5; i++) {
+      now += 1000;
+      $scope.on_streamsUpdate(null, streams);
+    }
+
+    assert.strictEqual($scope.avgHistory, avgHist);
+    assert.strictEqual($scope.tripAvgHistory, tripHist);
+    assert.strictEqual($scope.tripAvgCostLiquid, tripCost);
     assert.strictEqual($scope.instantHistory, '');
   });
 

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1304,6 +1304,60 @@ describe('controller integration', () => {
     assert.strictEqual($scope.instantHistory, '');
   });
 
+  it('pauses updates when engineRunning flag is false despite rpm', () => {
+    let directiveDef;
+    global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };
+    global.StreamsManager = { add: () => {}, remove: () => {} };
+    global.UiUnits = { buildString: () => '' };
+    global.bngApi = { engineLua: () => '' };
+    const store = {
+      okFuelEconomyOverall: JSON.stringify({ queue: [], distance: 0, previousAvg: 0, previousAvgTrip: 0, fuelUsedLiquid: 0, fuelUsedElectric: 0 }),
+      okFuelEconomyAvgHistory: JSON.stringify({ queue: [] })
+    };
+    global.localStorage = { getItem: k => (k in store ? store[k] : null), setItem: (k,v) => { store[k] = v; } };
+    let now = 0;
+    global.performance = { now: () => now };
+
+    delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
+    require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+    const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
+    const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
+    controllerFn({ debug: () => {} }, $scope);
+
+    const streams = {
+      engineInfo: Array(15).fill(0),
+      electrics: { wheelspeed: 10, throttle_input: 0.5, rpmTacho: 1000, engineRunning: true, trip: 0 }
+    };
+    streams.engineInfo[11] = 60;
+    streams.engineInfo[12] = 80;
+
+    for (let i = 0; i < 3; i++) {
+      now += 1000;
+      streams.engineInfo[11] -= 0.1;
+      $scope.on_streamsUpdate(null, streams);
+    }
+
+    const avgHist = $scope.avgHistory;
+    const tripHist = $scope.tripAvgHistory;
+    const tripCost = $scope.tripAvgCostLiquid;
+
+    streams.electrics.engineRunning = false;
+    streams.electrics.throttle_input = 0;
+    streams.electrics.wheelspeed = 5;
+    streams.electrics.rpmTacho = 800;
+
+    for (let i = 0; i < 5; i++) {
+      now += 1000;
+      streams.engineInfo[11] -= 0.05;
+      $scope.on_streamsUpdate(null, streams);
+    }
+
+    assert.strictEqual($scope.avgHistory, avgHist);
+    assert.strictEqual($scope.tripAvgHistory, tripHist);
+    assert.strictEqual($scope.tripAvgCostLiquid, tripCost);
+    assert.strictEqual($scope.instantHistory, '');
+  });
+
   it('ignores unrealistic consumption spikes while stationary', () => {
     let directiveDef;
     global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };


### PR DESCRIPTION
## Summary
- ensure trip averages reuse last value while engine is off
- cover engine-off behaviour with tests
- bump project version to 1.0.6

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b77b9fad74832989a38b06c54998f4