### PR TITLE
Fix Node 18 test reporting

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { spawn } = require('child_process');
+const { run } = require('node:test');
 
 const testsDir = path.join(__dirname, '..', 'tests');
 const testFiles = fs
@@ -23,19 +24,72 @@ for (const arg of argv) {
   }
 }
 
-const child = spawn(
-  process.execPath,
-  ['--test', ...reporterArgs, ...otherArgs, ...testFiles],
-  {
-    env: { ...process.env, NODE_OPTIONS: '' },
-    stdio: 'inherit'
-  }
-);
+function escapeXml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
 
-child.on('close', (code, signal) => {
-  if (signal) {
-    process.kill(process.pid, signal);
-  } else {
-    process.exit(code);
-  }
-});
+if (major >= 20) {
+  const child = spawn(
+    process.execPath,
+    ['--test', ...reporterArgs, ...otherArgs, ...testFiles],
+    {
+      env: { ...process.env, NODE_OPTIONS: '' },
+      stdio: 'inherit'
+    }
+  );
+
+  child.on('close', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code);
+    }
+  });
+} else {
+  (async () => {
+    const cases = [];
+    let failures = 0;
+    const start = Date.now();
+    for await (const { type, data } of run({ files: testFiles })) {
+      if (data.details?.type !== 'test') continue;
+      if (type === 'test:pass') {
+        const t = (data.details?.duration_ms || 0) / 1000;
+        console.log(`\u2713 ${data.name}`);
+        cases.push(
+          `<testcase name="${escapeXml(data.name)}" time="${t}"></testcase>`
+        );
+      } else if (type === 'test:fail') {
+        const t = (data.details?.duration_ms || 0) / 1000;
+        const msg =
+          data.details?.error?.message ||
+          data.errors?.[0]?.message ||
+          'failed';
+        console.log(`\u2717 ${data.name}`);
+        if (data.details?.error) console.error(data.details.error);
+        if (data.errors)
+          data.errors.forEach((e) => console.error(e));
+        cases.push(
+          `<testcase name="${escapeXml(
+            data.name
+          )}" time="${t}"><failure>${escapeXml(msg)}</failure></testcase>`
+        );
+        failures++;
+      }
+    }
+    const total = cases.length;
+    const time = (Date.now() - start) / 1000;
+    const suite = `<?xml version="1.0" encoding="utf-8"?>\n<testsuite name="node" tests="${total}" failures="${failures}" errors="0" skipped="0" time="${time}">\n${cases.join(
+      '\n'
+    )}\n</testsuite>\n`;
+    fs.writeFileSync('test-results.xml', suite);
+    process.exit(failures > 0 ? 1 : 0);
+  })().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -56,7 +56,11 @@ if (major >= 20) {
     let failures = 0;
     const start = Date.now();
     for await (const { type, data } of run({ files: testFiles })) {
-      if (type !== 'test:pass' && type !== 'test:fail') continue;
+      if (
+        (type !== 'test:pass' && type !== 'test:fail') ||
+        data.details?.type !== 'test'
+      )
+        continue;
 
       const name = data.name || data.test?.name || 'unknown';
       const durationMs =

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -56,27 +56,28 @@ if (major >= 20) {
     let failures = 0;
     const start = Date.now();
     for await (const { type, data } of run({ files: testFiles })) {
-      if (data.details?.type !== 'test') continue;
+      if (type !== 'test:pass' && type !== 'test:fail') continue;
+
+      const name = data.name || data.test?.name || 'unknown';
+      const durationMs =
+        data.details?.duration_ms ?? data.test?.duration_ms ?? 0;
+      const t = durationMs / 1000;
+
       if (type === 'test:pass') {
-        const t = (data.details?.duration_ms || 0) / 1000;
-        console.log(`\u2713 ${data.name}`);
+        console.log(`\u2713 ${name}`);
         cases.push(
-          `<testcase name="${escapeXml(data.name)}" time="${t}"></testcase>`
+          `<testcase name="${escapeXml(name)}" time="${t}"></testcase>`
         );
-      } else if (type === 'test:fail') {
-        const t = (data.details?.duration_ms || 0) / 1000;
+      } else {
         const msg =
           data.details?.error?.message ||
           data.errors?.[0]?.message ||
           'failed';
-        console.log(`\u2717 ${data.name}`);
+        console.log(`\u2717 ${name}`);
         if (data.details?.error) console.error(data.details.error);
-        if (data.errors)
-          data.errors.forEach((e) => console.error(e));
+        if (data.errors) data.errors.forEach((e) => console.error(e));
         cases.push(
-          `<testcase name="${escapeXml(
-            data.name
-          )}" time="${t}"><failure>${escapeXml(msg)}</failure></testcase>`
+          `<testcase name="${escapeXml(name)}" time="${t}"><failure>${escapeXml(msg)}</failure></testcase>`
         );
         failures++;
       }


### PR DESCRIPTION
## Summary
- generate JUnit results for Node 18 using node:test events

## Testing
- `npm test -- --test-reporter=spec --test-reporter=junit --test-reporter-destination=stdout --test-reporter-destination=test-results.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b8f4b7e8f08329a3274421d1a2a070