### PR TITLE
Display fuel type and auto-switch units

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -32,6 +32,15 @@
       </td>
     </tr>
 
+    <tr ng-show="visible.fuelType">
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; width:38%; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
+        Fuel type:
+      </td>
+      <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#ccefff; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
+        <span>{{ fuelType }}</span>
+      </td>
+    </tr>
+
     <tr ng-show="visible.costPrice">
       <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; width:38%; color:#69e0ff; font-weight:500; text-shadow:0 0 3px rgba(0,255,255,0.4); border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         Fuel price:
@@ -262,6 +271,7 @@
     <label><input type="checkbox" ng-model="visible.fuelUsed"> Fuel used</label><br>
     <label><input type="checkbox" ng-model="visible.fuelLeft"> Fuel left</label><br>
     <label><input type="checkbox" ng-model="visible.fuelCap"> Fuel capacity</label><br>
+    <label><input type="checkbox" ng-model="visible.fuelType"> Fuel type</label><br>
       <label><input type="checkbox" ng-model="visible.avgL100km"> Average {{ unitConsumptionUnit }}</label><br>
       <label><input type="checkbox" ng-model="visible.avgKmL"> Average {{ unitEfficiencyUnit }}</label><br>
       <label><input type="checkbox" ng-model="visible.avgGraph"> Average history</label><br>

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -524,23 +524,18 @@ angular.module('beamng.apps')
           if (
             typeof window === 'undefined' ||
             typeof bngApi === 'undefined' ||
-            typeof bngApi.engineLua !== 'function'
+            typeof bngApi.activeObjectLua !== 'function'
           )
             return;
           var lua = [
             '(function()',
-            'local vid=be:getPlayerVehicleID(0)',
-            'if not vid then return jsonEncode({}) end',
-            'local veh=be:getObjectByID(vid)',
-            'if not veh then return jsonEncode({}) end',
-            'local es=veh.energyStorage',
-            'local stor=es and es.getStorages and es:getStorages()',
+            'local stor=energyStorage.getStorages and energyStorage.getStorages()',
             'local t=""',
             'if stor then for _,s in pairs(stor) do if s.energyType then t=s.energyType break end end end',
             'return jsonEncode({t=t})',
             'end)()'
           ].join('\n');
-          bngApi.engineLua(lua, function (res) {
+          bngApi.activeObjectLua(lua, function (res) {
             var parsed = {};
             try { parsed = JSON.parse(res); } catch (e) {}
             $scope.$evalAsync(function () {

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -257,6 +257,16 @@ function convertVolumePerDistance(lPerKm, mode) {
     : lPerKm;
 }
 
+function formatFuelTypeLabel(fuelType) {
+  if (
+    typeof fuelType === 'string' &&
+    fuelType.toLowerCase().indexOf('electric') !== -1
+  ) {
+    return 'electric';
+  }
+  return fuelType || '';
+}
+
 function resolveUnitModeForFuelType(fuelType, liquidMode) {
   if (
     typeof fuelType === 'string' &&
@@ -291,7 +301,8 @@ if (typeof module !== 'undefined') {
     convertVolumeToUnit,
     convertDistanceToUnit,
     convertVolumePerDistance,
-    resolveUnitModeForFuelType
+    resolveUnitModeForFuelType,
+    formatFuelTypeLabel
   };
 }
 
@@ -540,7 +551,7 @@ angular.module('beamng.apps')
             try { parsed = JSON.parse(res); } catch (e) {}
             $scope.$evalAsync(function () {
               lastFuelType = parsed.t || '';
-              $scope.fuelType = lastFuelType || '';
+              $scope.fuelType = formatFuelTypeLabel(lastFuelType);
               applyAutoUnitMode(lastFuelType);
             });
           });

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -530,19 +530,21 @@ angular.module('beamng.apps')
           var lua = [
             '(function()',
             'local vid=be:getPlayerVehicleID(0)',
-            'if not vid then return "" end',
+            'if not vid then return jsonEncode({}) end',
             'local veh=be:getObjectByID(vid)',
-            'if not veh then return "" end',
+            'if not veh then return jsonEncode({}) end',
             'local es=veh.energyStorage',
             'local stor=es and es.getStorages and es:getStorages()',
             'local t=""',
             'if stor then for _,s in pairs(stor) do if s.energyType then t=s.energyType break end end end',
-            'return t',
+            'return jsonEncode({t=t})',
             'end)()'
           ].join('\n');
           bngApi.engineLua(lua, function (res) {
+            var parsed = {};
+            try { parsed = JSON.parse(res); } catch (e) {}
             $scope.$evalAsync(function () {
-              lastFuelType = res || '';
+              lastFuelType = parsed.t || '';
               $scope.fuelType = lastFuelType || '';
               applyAutoUnitMode(lastFuelType);
             });

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -258,11 +258,14 @@ function convertVolumePerDistance(lPerKm, mode) {
 }
 
 function formatFuelTypeLabel(fuelType) {
-  if (
-    typeof fuelType === 'string' &&
-    fuelType.toLowerCase().indexOf('electric') !== -1
-  ) {
-    return 'electric';
+  if (typeof fuelType === 'string') {
+    var lower = fuelType.toLowerCase();
+    if (lower.indexOf('electric') !== -1) {
+      return 'electric';
+    }
+    if (lower === 'compressedgas') {
+      return 'LPG/CNG';
+    }
   }
   return fuelType || '';
 }

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -261,11 +261,12 @@ function formatFuelTypeLabel(fuelType) {
   if (typeof fuelType === 'string') {
     var lower = fuelType.toLowerCase();
     if (lower.indexOf('electric') !== -1) {
-      return 'electric';
+      return 'Electric';
     }
     if (lower === 'compressedgas') {
       return 'LPG/CNG';
     }
+    return lower.charAt(0).toUpperCase() + lower.slice(1);
   }
   return fuelType || '';
 }

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -529,7 +529,12 @@ angular.module('beamng.apps')
             return;
           var lua = [
             '(function()',
-            'local stor=energyStorage and energyStorage.getStorages and energyStorage.getStorages()',
+            'local vid=be:getPlayerVehicleID(0)',
+            'if not vid then return "" end',
+            'local veh=be:getObjectByID(vid)',
+            'if not veh then return "" end',
+            'local es=veh.energyStorage',
+            'local stor=es and es.getStorages and es:getStorages()',
             'local t=""',
             'if stor then for _,s in pairs(stor) do if s.energyType then t=s.energyType break end end end',
             'return t',

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -316,6 +316,9 @@ describe('app.js utility functions', () => {
     it('maps electric energy types to "electric"', () => {
       assert.strictEqual(formatFuelTypeLabel('electricEnergy'), 'electric');
     });
+    it('maps compressed gas to "LPG/CNG"', () => {
+      assert.strictEqual(formatFuelTypeLabel('compressedGas'), 'LPG/CNG');
+    });
     it('returns other types unchanged', () => {
       assert.strictEqual(formatFuelTypeLabel('diesel'), 'diesel');
     });

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -22,7 +22,8 @@ const {
   formatEfficiency,
   formatFlow,
   MIN_VALID_SPEED_MPS,
-  resolveUnitModeForFuelType
+  resolveUnitModeForFuelType,
+  formatFuelTypeLabel
 } = require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
 
 describe('app.js utility functions', () => {
@@ -299,7 +300,7 @@ describe('app.js utility functions', () => {
   describe('resolveUnitModeForFuelType', () => {
     it('uses electric units for electric storages', () => {
       assert.strictEqual(
-        resolveUnitModeForFuelType('electricBattery', 'metric'),
+        resolveUnitModeForFuelType('electricEnergy', 'metric'),
         'electric'
       );
     });
@@ -308,6 +309,15 @@ describe('app.js utility functions', () => {
         resolveUnitModeForFuelType('diesel', 'imperial'),
         'imperial'
       );
+    });
+  });
+
+  describe('formatFuelTypeLabel', () => {
+    it('maps electric energy types to "electric"', () => {
+      assert.strictEqual(formatFuelTypeLabel('electricEnergy'), 'electric');
+    });
+    it('returns other types unchanged', () => {
+      assert.strictEqual(formatFuelTypeLabel('diesel'), 'diesel');
     });
   });
 });

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -313,14 +313,14 @@ describe('app.js utility functions', () => {
   });
 
   describe('formatFuelTypeLabel', () => {
-    it('maps electric energy types to "electric"', () => {
-      assert.strictEqual(formatFuelTypeLabel('electricEnergy'), 'electric');
+    it('maps electric energy types to "Electric"', () => {
+      assert.strictEqual(formatFuelTypeLabel('electricEnergy'), 'Electric');
     });
     it('maps compressed gas to "LPG/CNG"', () => {
       assert.strictEqual(formatFuelTypeLabel('compressedGas'), 'LPG/CNG');
     });
-    it('returns other types unchanged', () => {
-      assert.strictEqual(formatFuelTypeLabel('diesel'), 'diesel');
+    it('capitalizes other types', () => {
+      assert.strictEqual(formatFuelTypeLabel('diesel'), 'Diesel');
     });
   });
 });

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -21,7 +21,8 @@ const {
   formatConsumptionRate,
   formatEfficiency,
   formatFlow,
-  MIN_VALID_SPEED_MPS
+  MIN_VALID_SPEED_MPS,
+  resolveUnitModeForFuelType
 } = require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
 
 describe('app.js utility functions', () => {
@@ -292,6 +293,21 @@ describe('app.js utility functions', () => {
     });
     it('formats flow in kW', () => {
       assert.strictEqual(formatFlow(5, 'electric', 1), '5.0 kW');
+    });
+  });
+
+  describe('resolveUnitModeForFuelType', () => {
+    it('uses electric units for electric storages', () => {
+      assert.strictEqual(
+        resolveUnitModeForFuelType('electricBattery', 'metric'),
+        'electric'
+      );
+    });
+    it('falls back to preferred liquid units for non-electric', () => {
+      assert.strictEqual(
+        resolveUnitModeForFuelType('diesel', 'imperial'),
+        'imperial'
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- show vehicle fuel type with toggleable UI row
- auto-select electric units when energy type is electric and revert to preferred liquid units
- cover fuel type unit logic with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb7c34524c8329929015c5d24fb70f