### PR TITLE
feat: support per-fuel pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Fuel cost calculations use values stored in `AppData/Local/BeamNG.drive/{version
 1. Use the in-game fuel price dialog to set the values directly. This UI writes to the same `fuelPrice.json` file.
 2. Manually edit `fuelPrice.json` yourself (for example `C:/Users/<your user>/AppData/Local/BeamNG.drive/<version>/settings/krtektm_fuelEconomy/fuelPrice.json` on Windows) and set the values inside the `prices` object (such as `Gasoline` and `Electricity`), optionally adding a `currency` label (e.g. `$`, `€`).
 
+Existing installations using the legacy `liquidFuelPrice` and `electricityPrice` fields are upgraded automatically when the app loads.
+
 The controller loads these prices at runtime and computes average cost per distance, trip average cost per distance, total fuel cost and trip total fuel cost when the relevant fields are enabled in settings.
 Trip costs accumulate only while their respective unit mode is active: liquid costs grow when using metric or imperial units, whereas electric costs grow when using the electric unit mode.
 Any edits to the file—whether done manually or via the dialog—while the game is running are picked up automatically so prices can be changed without restarting.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Data are gathered via `StreamsManager` from the *electrics* and *engineInfo* cha
 Fuel cost calculations use values stored in `AppData/Local/BeamNG.drive/{version}/settings/krtektm_fuelEconomy/fuelPrice.json`. You can change them in two ways:
 
 1. Use the in-game fuel price dialog to set the values directly. This UI writes to the same `fuelPrice.json` file.
-2. Manually edit `fuelPrice.json` yourself (for example `C:/Users/<your user>/AppData/Local/BeamNG.drive/<version>/settings/krtektm_fuelEconomy/fuelPrice.json` on Windows) and set the `liquidFuelPrice` and `electricityPrice` values, optionally adding a `currency` label (e.g. `$`, `€`).
+2. Manually edit `fuelPrice.json` yourself (for example `C:/Users/<your user>/AppData/Local/BeamNG.drive/<version>/settings/krtektm_fuelEconomy/fuelPrice.json` on Windows) and set the values inside the `prices` object (such as `Gasoline` and `Electricity`), optionally adding a `currency` label (e.g. `$`, `€`).
 
 The controller loads these prices at runtime and computes average cost per distance, trip average cost per distance, total fuel cost and trip total fuel cost when the relevant fields are enabled in settings.
 Trip costs accumulate only while their respective unit mode is active: liquid costs grow when using metric or imperial units, whereas electric costs grow when using the electric unit mode.

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -203,7 +203,7 @@
       <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#FFE7CC; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         <span>Liquid: {{ tripFuelUsedLiquid }}</span>
         <span> | </span>
-        <span>Electric: {{ tripFuelUsedElectric }}</span>
+        <span>Electricity: {{ tripFuelUsedElectric }}</span>
       </td>
     </tr>
 
@@ -214,7 +214,7 @@
       <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#FFE7CC; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         <span>Liquid: {{ tripAvgCostLiquid }}</span>
         <span> | </span>
-        <span>Electric: {{ tripAvgCostElectric }}</span>
+        <span>Electricity: {{ tripAvgCostElectric }}</span>
       </td>
     </tr>
 
@@ -225,7 +225,7 @@
       <td ng-attr-style="{{ useCustomStyles ? 'padding:3px 2px; color:#FFE7CC; border-bottom:1px solid rgba(0,180,255,0.10);' : '' }}">
         <span>Liquid: {{ tripTotalCostLiquid }}</span>
         <span> | </span>
-        <span>Electric: {{ tripTotalCostElectric }}</span>
+        <span>Electricity: {{ tripTotalCostElectric }}</span>
       </td>
     </tr>
 

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -570,7 +570,10 @@ angular.module('beamng.apps')
             '(function()',
             'local stor=energyStorage.getStorages and energyStorage.getStorages()',
             'local t=""',
-            'if stor then for _,s in pairs(stor) do if s.energyType then t=s.energyType break end end end',
+            'if stor then',
+            '  for _,s in pairs(stor) do if s.energyType and s.energyType:lower()~="air" then t=s.energyType break end end',
+            '  if t=="" then for _,s in pairs(stor) do if s.energyType then t=s.energyType break end end end',
+            'end',
             'return jsonEncode({t=t})',
             'end)()'
           ].join('\n');

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -261,7 +261,7 @@ function formatFuelTypeLabel(fuelType) {
   if (typeof fuelType === 'string') {
     var lower = fuelType.toLowerCase();
     if (lower.indexOf('electric') !== -1) {
-      return 'Electric';
+      return 'Electricity';
     }
     if (lower === 'compressedgas') {
       return 'LPG/CNG';

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -374,6 +374,7 @@ function loadFuelPriceConfig(callback) {
         prices,
         currency: data.currency || 'money'
       };
+      fs.writeFileSync(userFile, JSON.stringify(cfgObj));
       if (typeof callback === 'function') callback(cfgObj);
       return cfgObj;
     } catch (e) {

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -460,6 +460,7 @@ angular.module('beamng.apps')
             $scope.currency = cfg.currency;
             updateCostPrice();
             setTimeout(refreshCostOutputs, 0);
+            fetchFuelType();
           };
           if (typeof $scope.$evalAsync === 'function') $scope.$evalAsync(applyInit); else applyInit();
         });
@@ -478,7 +479,11 @@ angular.module('beamng.apps')
             ) {
               var apply = function () {
                 $scope.fuelPrices = cfg.prices || {};
-                $scope.liquidFuelPriceValue = $scope.fuelPrices[$scope.fuelType] || $scope.fuelPrices.Gasoline || 0;
+                var ftPrice = $scope.fuelPrices[$scope.fuelType];
+                $scope.liquidFuelPriceValue =
+                  typeof ftPrice === 'number'
+                    ? ftPrice
+                    : $scope.fuelPrices.Gasoline || 0;
                 $scope.electricityPriceValue = $scope.fuelPrices.Electricity || 0;
                 $scope.currency = cfg.currency;
                 updateCostPrice();
@@ -543,7 +548,6 @@ angular.module('beamng.apps')
         }
         updateUnitLabels();
         updateCostPrice();
-        fetchFuelType();
 
         function applyAutoUnitMode(type) {
           var desired = resolveUnitModeForFuelType(type, preferredLiquidUnit);

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -312,8 +312,7 @@ if (typeof module !== 'undefined') {
 
 function loadFuelPriceConfig(callback) {
   var defaults = {
-    liquidFuelPrice: 0,
-    electricityPrice: 0,
+    prices: { Gasoline: 0, Electricity: 0 },
     currency: 'money'
   };
 
@@ -353,15 +352,26 @@ function loadFuelPriceConfig(callback) {
       );
       fs.mkdirSync(settingsDir, { recursive: true });
       const userFile = path.join(settingsDir, 'fuelPrice.json');
+      loadFuelPriceConfig.userFile = userFile;
       if (!fs.existsSync(userFile)) {
         fs.copyFileSync(path.join(__dirname, 'fuelPrice.json'), userFile);
         if (typeof callback === 'function') callback(defaults);
         return defaults;
       }
       const data = JSON.parse(fs.readFileSync(userFile, 'utf8'));
+      var prices = {};
+      if (data.prices && typeof data.prices === 'object') {
+        Object.keys(data.prices).forEach(k => {
+          prices[k] = parseFloat(data.prices[k]) || 0;
+        });
+      } else {
+        if (typeof data.liquidFuelPrice !== 'undefined') prices.Gasoline = parseFloat(data.liquidFuelPrice) || 0;
+        if (typeof data.electricityPrice !== 'undefined') prices.Electricity = parseFloat(data.electricityPrice) || 0;
+      }
+      if (prices.Gasoline === undefined) prices.Gasoline = 0;
+      if (prices.Electricity === undefined) prices.Electricity = 0;
       const cfgObj = {
-        liquidFuelPrice: parseFloat(data.liquidFuelPrice) || 0,
-        electricityPrice: parseFloat(data.electricityPrice) || 0,
+        prices,
         currency: data.currency || 'money'
       };
       if (typeof callback === 'function') callback(cfgObj);
@@ -381,8 +391,14 @@ function loadFuelPriceConfig(callback) {
         'FS:directoryCreate(dir)',
         "local p=dir..'fuelPrice.json'",
         'local cfg=jsonReadFile(p)',
-        "if not cfg then cfg={liquidFuelPrice=0,electricityPrice=0,currency='money'} jsonWriteFile(p,cfg) end",
-        "return jsonEncode({liquidFuelPrice=tonumber(cfg.liquidFuelPrice) or 0,electricityPrice=tonumber(cfg.electricityPrice) or 0,currency=cfg.currency or 'money'})",
+        "if not cfg then cfg={prices={Gasoline=0,Electricity=0},currency='money'} jsonWriteFile(p,cfg) end",
+        "if not cfg.prices then cfg.prices={Gasoline=0,Electricity=0} end",
+        "if cfg.liquidFuelPrice then cfg.prices.Gasoline=cfg.liquidFuelPrice cfg.liquidFuelPrice=nil end",
+        "if cfg.electricityPrice then cfg.prices.Electricity=cfg.electricityPrice cfg.electricityPrice=nil end",
+        "if cfg.prices.Gasoline==nil then cfg.prices.Gasoline=0 end",
+        "if cfg.prices.Electricity==nil then cfg.prices.Electricity=0 end",
+        'jsonWriteFile(p,cfg)',
+        "return jsonEncode({prices=cfg.prices,currency=cfg.currency or 'money'})",
         'end)()'
       ].join('\n');
       bngApi.engineLua(lua, function (res) {
@@ -411,6 +427,7 @@ angular.module('beamng.apps')
       var streamsList = ['electrics', 'engineInfo'];
       StreamsManager.add(streamsList);
 
+        $scope.fuelPrices = { Gasoline: 0, Electricity: 0 };
         $scope.liquidFuelPriceValue = 0;
         $scope.electricityPriceValue = 0;
         $scope.currency = 'money';
@@ -436,8 +453,9 @@ angular.module('beamng.apps')
 
         loadFuelPriceConfig(function (cfg) {
           var applyInit = function () {
-            $scope.liquidFuelPriceValue = cfg.liquidFuelPrice;
-            $scope.electricityPriceValue = cfg.electricityPrice;
+            $scope.fuelPrices = cfg.prices || { Gasoline: 0, Electricity: 0 };
+            $scope.liquidFuelPriceValue = $scope.fuelPrices.Gasoline || 0;
+            $scope.electricityPriceValue = $scope.fuelPrices.Electricity || 0;
             $scope.currency = cfg.currency;
             updateCostPrice();
             setTimeout(refreshCostOutputs, 0);
@@ -452,14 +470,15 @@ angular.module('beamng.apps')
       }
         var priceTimer = setInterval(function () {
           loadFuelPriceConfig(function (cfg) {
+            var pricesChanged = JSON.stringify(cfg.prices || {}) !== JSON.stringify($scope.fuelPrices);
             if (
-              cfg.liquidFuelPrice !== $scope.liquidFuelPriceValue ||
-              cfg.electricityPrice !== $scope.electricityPriceValue ||
+              pricesChanged ||
               cfg.currency !== $scope.currency
             ) {
               var apply = function () {
-                $scope.liquidFuelPriceValue = cfg.liquidFuelPrice;
-                $scope.electricityPriceValue = cfg.electricityPrice;
+                $scope.fuelPrices = cfg.prices || {};
+                $scope.liquidFuelPriceValue = $scope.fuelPrices[$scope.fuelType] || $scope.fuelPrices.Gasoline || 0;
+                $scope.electricityPriceValue = $scope.fuelPrices.Electricity || 0;
                 $scope.currency = cfg.currency;
                 updateCostPrice();
                 refreshCostOutputs();
@@ -556,7 +575,25 @@ angular.module('beamng.apps')
             $scope.$evalAsync(function () {
               lastFuelType = parsed.t || '';
               $scope.fuelType = formatFuelTypeLabel(lastFuelType);
+              if ($scope.fuelPrices[$scope.fuelType] == null) {
+                $scope.fuelPrices[$scope.fuelType] = 0;
+                if (typeof require === 'function' && loadFuelPriceConfig.userFile) {
+                  try {
+                    const fs = require('fs');
+                    const data = { prices: $scope.fuelPrices, currency: $scope.currency };
+                    fs.writeFileSync(loadFuelPriceConfig.userFile, JSON.stringify(data));
+                  } catch (e) {}
+                } else if (typeof bngApi !== 'undefined' && typeof bngApi.engineLua === 'function') {
+                  var cmd = 'extensions.load("fuelPriceEditor")';
+                  bngApi.engineLua(cmd, function () {
+                    bngApi.engineLua('extensions.fuelPriceEditor.ensureFuelType(' + JSON.stringify($scope.fuelType) + ')');
+                  });
+                }
+              }
+              $scope.liquidFuelPriceValue = $scope.fuelPrices[$scope.fuelType] || 0;
               applyAutoUnitMode(lastFuelType);
+              updateCostPrice();
+              refreshCostOutputs();
             });
           });
         }

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/fuelPrice.json
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/fuelPrice.json
@@ -1,5 +1,7 @@
 {
-  "liquidFuelPrice": 0,
-  "electricityPrice": 0,
+  "prices": {
+    "Gasoline": 0,
+    "Electricity": 0
+  },
   "currency": "money"
 }

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -313,8 +313,8 @@ describe('app.js utility functions', () => {
   });
 
   describe('formatFuelTypeLabel', () => {
-    it('maps electric energy types to "Electric"', () => {
-      assert.strictEqual(formatFuelTypeLabel('electricEnergy'), 'Electric');
+    it('maps electric energy types to "Electricity"', () => {
+      assert.strictEqual(formatFuelTypeLabel('electricEnergy'), 'Electricity');
     });
     it('maps compressed gas to "LPG/CNG"', () => {
       assert.strictEqual(formatFuelTypeLabel('compressedGas'), 'LPG/CNG');

--- a/tests/fuelPriceEditor.test.js
+++ b/tests/fuelPriceEditor.test.js
@@ -14,8 +14,7 @@ describe('Fuel Price Editor saving', () => {
 
     const data = {};
     const uiState = {
-      liquid: { 0: 0 },
-      electric: { 0: 0 },
+      prices: { Gasoline: { 0: 0 }, Electricity: { 0: 0 } },
       currency: { value: 'money' }
     };
 
@@ -30,19 +29,24 @@ describe('Fuel Price Editor saving', () => {
 
     function ensureFile() {
       if (!FS.directoryExists(priceDir)) FS.directoryCreate(priceDir);
-      if (!FS.fileExists(pricePath)) jsonWriteFile(pricePath, { liquidFuelPrice: 0, electricityPrice: 0, currency: 'money' });
+      if (!FS.fileExists(pricePath)) jsonWriteFile(pricePath, { prices: { Gasoline: 0, Electricity: 0 }, currency: 'money' });
     }
 
     function loadPrices() {
-      Object.assign(data, jsonReadFile(pricePath));
-      uiState.liquid[0] = data.liquidFuelPrice;
-      uiState.electric[0] = data.electricityPrice;
-      uiState.currency.value = data.currency;
+      const read = jsonReadFile(pricePath);
+      Object.assign(data, read);
+      uiState.prices = {};
+      Object.keys(read.prices).forEach(k => {
+        uiState.prices[k] = { 0: read.prices[k] };
+      });
+      uiState.currency.value = read.currency;
     }
 
     function savePrices() {
-      data.liquidFuelPrice = uiState.liquid[0];
-      data.electricityPrice = uiState.electric[0];
+      data.prices = {};
+      Object.keys(uiState.prices).forEach(k => {
+        data.prices[k] = uiState.prices[k][0];
+      });
       data.currency = uiState.currency.value;
       jsonWriteFile(pricePath, data);
       loadPrices();
@@ -50,12 +54,12 @@ describe('Fuel Price Editor saving', () => {
 
     ensureFile();
     loadPrices();
-    uiState.liquid[0] = 3.7;
-    uiState.electric[0] = 1.6;
+    uiState.prices.Gasoline[0] = 3.7;
+    uiState.prices.Electricity[0] = 1.6;
     uiState.currency.value = 'EUR';
     savePrices();
 
     const saved = jsonReadFile(pricePath);
-    assert.deepStrictEqual(saved, { liquidFuelPrice: 3.7, electricityPrice: 1.6, currency: 'EUR' });
+    assert.deepStrictEqual(saved, { prices: { Gasoline: 3.7, Electricity: 1.6 }, currency: 'EUR' });
   });
 });

--- a/tests/stress.test.js
+++ b/tests/stress.test.js
@@ -199,6 +199,7 @@ test('restart and manual reset cycle', () => {
     const $scope = { $on: (n, cb) => { $scope['on_' + n] = cb; }, $evalAsync: fn => fn() };
     controller({ debug: () => {} }, $scope);
     if (prevDir === undefined) delete process.env.KRTEKTM_BNG_USER_DIR; else process.env.KRTEKTM_BNG_USER_DIR = prevDir;
+    $scope.fuelPrices.Gasoline = 2;
     $scope.liquidFuelPriceValue = 2; // ensure costs are non-zero
     return { $scope, setTime: t => { now = t; } };
   }

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -123,8 +123,9 @@ describe('UI template styling', () => {
   it('exposes fuel prices and currency in fuelPrice.json', () => {
     const priceConfigPath = path.join(__dirname, '..', 'okFuelEconomy', 'ui', 'modules', 'apps', 'okFuelEconomy', 'fuelPrice.json');
     const cfg = JSON.parse(fs.readFileSync(priceConfigPath, 'utf8'));
-    assert.ok(Object.prototype.hasOwnProperty.call(cfg, 'liquidFuelPrice'));
-    assert.ok(Object.prototype.hasOwnProperty.call(cfg, 'electricityPrice'));
+    assert.ok(Object.prototype.hasOwnProperty.call(cfg, 'prices'));
+    assert.ok(Object.prototype.hasOwnProperty.call(cfg.prices, 'Gasoline'));
+    assert.ok(Object.prototype.hasOwnProperty.call(cfg.prices, 'Electricity'));
     assert.ok(Object.prototype.hasOwnProperty.call(cfg, 'currency'));
   });
 
@@ -144,7 +145,7 @@ describe('UI template styling', () => {
     fs.mkdirSync(verDir, { recursive: true });
     fs.writeFileSync(
       path.join(verDir, 'fuelPrice.json'),
-      JSON.stringify({ liquidFuelPrice: 2.25, electricityPrice: 0.5, currency: 'CZK' })
+      JSON.stringify({ prices: { Gasoline: 2.25, Electricity: 0.5 }, currency: 'CZK' })
     );
 
     delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
@@ -176,7 +177,7 @@ describe('UI template styling', () => {
     const verDir = path.join(tmp, '0.98', 'settings', 'krtektm_fuelEconomy');
     fs.mkdirSync(verDir, { recursive: true });
     const cfgPath = path.join(verDir, 'fuelPrice.json');
-    fs.writeFileSync(cfgPath, JSON.stringify({ liquidFuelPrice: 1, electricityPrice: 0.2, currency: 'USD' }));
+    fs.writeFileSync(cfgPath, JSON.stringify({ prices: { Gasoline: 1, Electricity: 0.2 }, currency: 'USD' }));
 
     delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
     require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
@@ -189,7 +190,7 @@ describe('UI template styling', () => {
     assert.strictEqual($scope.electricityPriceValue, 0.2);
     assert.strictEqual($scope.currency, 'USD');
 
-    fs.writeFileSync(cfgPath, JSON.stringify({ liquidFuelPrice: 3, electricityPrice: 0.8, currency: 'EUR' }));
+    fs.writeFileSync(cfgPath, JSON.stringify({ prices: { Gasoline: 3, Electricity: 0.8 }, currency: 'EUR' }));
     await new Promise(r => setTimeout(r, 60));
     assert.strictEqual($scope.liquidFuelPriceValue, 3);
     assert.strictEqual($scope.electricityPriceValue, 0.8);
@@ -213,7 +214,7 @@ describe('UI template styling', () => {
     const tmp = fs.mkdtempSync(path.join(require('os').tmpdir(), 'fuel-'));
     const cfgPath = path.join(tmp, 'settings', 'krtektm_fuelEconomy', 'fuelPrice.json');
     fs.mkdirSync(path.dirname(cfgPath), { recursive: true });
-    fs.writeFileSync(cfgPath, JSON.stringify({ liquidFuelPrice: 4, electricityPrice: 1.2, currency: 'Kč' }));
+    fs.writeFileSync(cfgPath, JSON.stringify({ prices: { Gasoline: 4, Electricity: 1.2 }, currency: 'Kč' }));
 
     global.bngApi = {
       engineLua: (code, cb) => {
@@ -222,7 +223,7 @@ describe('UI template styling', () => {
         try {
           cb(fs.readFileSync(cfgPath, 'utf8'));
         } catch (e) {
-          cb(JSON.stringify({ liquidFuelPrice: 0, electricityPrice: 0, currency: 'money' }));
+          cb(JSON.stringify({ prices: { Gasoline: 0, Electricity: 0 }, currency: 'money' }));
         }
       }
     };
@@ -244,7 +245,7 @@ describe('UI template styling', () => {
     assert.strictEqual($scope.electricityPriceValue, 1.2);
     assert.strictEqual($scope.currency, 'Kč');
 
-    fs.writeFileSync(cfgPath, JSON.stringify({ liquidFuelPrice: 5, electricityPrice: 1.5, currency: '€' }));
+    fs.writeFileSync(cfgPath, JSON.stringify({ prices: { Gasoline: 5, Electricity: 1.5 }, currency: '€' }));
     await new Promise(r => setTimeout(r, 60));
     assert.strictEqual($scope.liquidFuelPriceValue, 5);
     assert.strictEqual($scope.electricityPriceValue, 1.5);
@@ -302,7 +303,7 @@ describe('UI template styling', () => {
 
     const cfgPath = path.join(tmp, '0.50', 'settings', 'krtektm_fuelEconomy', 'fuelPrice.json');
     const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
-    assert.strictEqual(cfg.liquidFuelPrice, 0);
+    assert.strictEqual(cfg.prices.Gasoline, 0);
 
     delete process.env.KRTEKTM_BNG_USER_DIR;
   });
@@ -411,7 +412,7 @@ describe('controller integration', () => {
     fs.mkdirSync(verDir, { recursive: true });
     fs.writeFileSync(
       path.join(verDir, 'fuelPrice.json'),
-      JSON.stringify({ liquidFuelPrice: 1.5, electricityPrice: 0.5, currency: 'USD' })
+      JSON.stringify({ prices: { Gasoline: 1.5, Electricity: 0.5 }, currency: 'USD' })
     );
 
     delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
@@ -443,7 +444,7 @@ describe('controller integration', () => {
     fs.mkdirSync(verDir, { recursive: true });
     fs.writeFileSync(
       path.join(verDir, 'fuelPrice.json'),
-      JSON.stringify({ liquidFuelPrice: 1.5, electricityPrice: 0.5, currency: 'USD' })
+      JSON.stringify({ prices: { Gasoline: 1.5, Electricity: 0.5 }, currency: 'USD' })
     );
 
     delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
@@ -526,7 +527,7 @@ describe('controller integration', () => {
     fs.mkdirSync(verDir, { recursive: true });
     fs.writeFileSync(
       path.join(verDir, 'fuelPrice.json'),
-      JSON.stringify({ liquidFuelPrice: 1.5, electricityPrice: 0.5, currency: 'USD' })
+      JSON.stringify({ prices: { Gasoline: 1.5, Electricity: 0.5 }, currency: 'USD' })
     );
 
     delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
@@ -571,7 +572,7 @@ describe('controller integration', () => {
     fs.mkdirSync(verDir, { recursive: true });
     fs.writeFileSync(
       path.join(verDir, 'fuelPrice.json'),
-      JSON.stringify({ liquidFuelPrice: 1.5, electricityPrice: 0.5, currency: 'USD' })
+      JSON.stringify({ prices: { Gasoline: 1.5, Electricity: 0.5 }, currency: 'USD' })
     );
 
     delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
@@ -627,7 +628,7 @@ describe('controller integration', () => {
     fs.mkdirSync(verDir, { recursive: true });
     fs.writeFileSync(
       path.join(verDir, 'fuelPrice.json'),
-      JSON.stringify({ liquidFuelPrice: 1.5, electricityPrice: 0, currency: 'USD' })
+      JSON.stringify({ prices: { Gasoline: 1.5, Electricity: 0 }, currency: 'USD' })
     );
 
     delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
@@ -685,7 +686,7 @@ describe('controller integration', () => {
     fs.mkdirSync(verDir, { recursive: true });
     fs.writeFileSync(
       path.join(verDir, 'fuelPrice.json'),
-      JSON.stringify({ liquidFuelPrice: 1.5, electricityPrice: 0, currency: 'USD' })
+      JSON.stringify({ prices: { Gasoline: 1.5, Electricity: 0 }, currency: 'USD' })
     );
 
     delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
@@ -759,7 +760,7 @@ describe('controller integration', () => {
     fs.mkdirSync(verDir, { recursive: true });
     fs.writeFileSync(
       path.join(verDir, 'fuelPrice.json'),
-      JSON.stringify({ liquidFuelPrice: 1.5, electricityPrice: 0, currency: 'USD' })
+      JSON.stringify({ prices: { Gasoline: 1.5, Electricity: 0 }, currency: 'USD' })
     );
 
     function loadController() {
@@ -830,7 +831,7 @@ describe('controller integration', () => {
     fs.mkdirSync(verDir, { recursive: true });
     fs.writeFileSync(
       path.join(verDir, 'fuelPrice.json'),
-      JSON.stringify({ liquidFuelPrice: 32.5, electricityPrice: 0, currency: 'money' })
+      JSON.stringify({ prices: { Gasoline: 32.5, Electricity: 0 }, currency: 'money' })
     );
 
     delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -67,11 +67,11 @@ describe('UI template styling', () => {
     assert.ok(html.includes('{{ avgCost }}'));
     assert.ok(html.includes('{{ totalCost }}'));
     assert.ok(html.includes('Liquid: {{ tripAvgCostLiquid }}'));
-    assert.ok(html.includes('Electric: {{ tripAvgCostElectric }}'));
+    assert.ok(html.includes('Electricity: {{ tripAvgCostElectric }}'));
     assert.ok(html.includes('Liquid: {{ tripTotalCostLiquid }}'));
-    assert.ok(html.includes('Electric: {{ tripTotalCostElectric }}'));
+    assert.ok(html.includes('Electricity: {{ tripTotalCostElectric }}'));
     assert.ok(html.includes('Liquid: {{ tripFuelUsedLiquid }}'));
-    assert.ok(html.includes('Electric: {{ tripFuelUsedElectric }}'));
+    assert.ok(html.includes('Electricity: {{ tripFuelUsedElectric }}'));
   });
 
   it('loads fuel price editor via controller function', async () => {


### PR DESCRIPTION
## Summary
- allow editing multiple fuel types in the Fuel Price Editor
- load and persist prices per fuel type, defaulting gasoline and electricity
- document new `fuelPrice.json` format and update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb8fef47e08329b30b84602108a2a4