### PR TITLE
feat: allow removing fuel types

### DIFF
--- a/okFuelEconomy/lua/ge/extensions/fuelPriceEditor.lua
+++ b/okFuelEconomy/lua/ge/extensions/fuelPriceEditor.lua
@@ -100,7 +100,8 @@ local function onUpdate()
     im.SameLine()
     local disabled = name == 'Gasoline' or name == 'Electricity'
     if disabled then im.BeginDisabled() end
-    if im.Button('Delete##' .. name) then
+    local label = (im.Icons and (im.Icons.Trash or im.Icons.Delete) or 'Delete') .. '##' .. name
+    if im.Button(label) then
       removeFuelType(name)
     end
     if disabled then im.EndDisabled() end

--- a/okFuelEconomy/lua/ge/extensions/fuelPriceEditor.lua
+++ b/okFuelEconomy/lua/ge/extensions/fuelPriceEditor.lua
@@ -79,6 +79,15 @@ local function savePrices()
   loadPrices()
 end
 
+local function removeFuelType(name)
+  if name == 'Gasoline' or name == 'Electricity' then return end
+  if uiState.prices[name] == nil then return end
+  uiState.prices[name] = nil
+  data.prices = data.prices or {}
+  data.prices[name] = nil
+  savePrices()
+end
+
 local function onUpdate()
   im.Begin('Fuel Price Editor')
   local names = {}
@@ -88,6 +97,13 @@ local function onUpdate()
   table.sort(names)
   for _, name in ipairs(names) do
     im.InputFloat(name, uiState.prices[name])
+    im.SameLine()
+    local disabled = name == 'Gasoline' or name == 'Electricity'
+    if disabled then im.BeginDisabled() end
+    if im.Button('Delete##' .. name) then
+      removeFuelType(name)
+    end
+    if disabled then im.EndDisabled() end
   end
   im.InputText('Currency', uiState.currency)
 

--- a/okFuelEconomy/lua/ge/extensions/fuelPriceEditor.lua
+++ b/okFuelEconomy/lua/ge/extensions/fuelPriceEditor.lua
@@ -100,8 +100,7 @@ local function onUpdate()
     im.SameLine()
     local disabled = name == 'Gasoline' or name == 'Electricity'
     if disabled then im.BeginDisabled() end
-    local label = (im.Icons and (im.Icons.Trash or im.Icons.Delete) or 'Delete') .. '##' .. name
-    if im.Button(label) then
+    if im.Button('Remove##' .. name) then
       removeFuelType(name)
     end
     if disabled then im.EndDisabled() end

--- a/tests/fuelPriceEditor.test.js
+++ b/tests/fuelPriceEditor.test.js
@@ -209,7 +209,7 @@ describe('Fuel Price Editor ordering', () => {
         im.SameLine();
         const disabled = name === 'Gasoline' || name === 'Electricity';
         if (disabled) im.BeginDisabled();
-        const label = ((im.Icons && (im.Icons.Trash || im.Icons.Delete)) || 'Delete') + '##' + name;
+        const label = 'Remove##' + name;
         im.Button(label);
         if (disabled) im.EndDisabled();
       });

--- a/tests/fuelPriceEditor.test.js
+++ b/tests/fuelPriceEditor.test.js
@@ -209,7 +209,8 @@ describe('Fuel Price Editor ordering', () => {
         im.SameLine();
         const disabled = name === 'Gasoline' || name === 'Electricity';
         if (disabled) im.BeginDisabled();
-        im.Button('Delete##' + name);
+        const label = ((im.Icons && (im.Icons.Trash || im.Icons.Delete)) || 'Delete') + '##' + name;
+        im.Button(label);
         if (disabled) im.EndDisabled();
       });
       im.InputText('Currency', uiState.currency);


### PR DESCRIPTION
## Summary
- add delete buttons to Fuel Price Editor to remove fuel types from JSON
- disable deletion of Gasoline and Electricity
- test removal workflow and button ordering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc8d34e7508329add4b2446a8cbd65