### PR TITLE
Show fuel units in price editor

### DIFF
--- a/okFuelEconomy/lua/ge/extensions/fuelPriceEditor.lua
+++ b/okFuelEconomy/lua/ge/extensions/fuelPriceEditor.lua
@@ -11,6 +11,14 @@ local uiState = {
   currency = im.ArrayChar(32, 'money')
 }
 
+local liquidUnit = 'L'
+
+local function unitLabel(name)
+  if name == 'Electricity' then return 'kWh' end
+  if name == 'Food' then return 'kcal' end
+  return liquidUnit
+end
+
 local function migrate(cfg)
   local migrated = false
   cfg.prices = cfg.prices or {}
@@ -96,7 +104,8 @@ local function onUpdate()
   end
   table.sort(names)
   for _, name in ipairs(names) do
-    im.InputFloat(name, uiState.prices[name])
+    local unit = unitLabel(name)
+    im.InputFloat(string.format('%s (%s)##%s', name, unit, name), uiState.prices[name])
     im.SameLine()
     local disabled = name == 'Gasoline' or name == 'Electricity'
     if disabled then im.BeginDisabled() end
@@ -128,6 +137,14 @@ end
 M.onUpdate = onUpdate
 M.onExtensionLoaded = onExtensionLoaded
 M.onFileChanged = onFileChanged
+
+function M.setLiquidUnit(unit)
+  if unit == 'gal' then
+    liquidUnit = 'gal'
+  else
+    liquidUnit = 'L'
+  end
+end
 
 function M.ensureFuelType(label)
   ensureFile()

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -534,7 +534,10 @@ angular.module('beamng.apps')
       $scope.settingsOpen = false;
       $scope.openFuelPriceEditor = function ($event) {
         $event.preventDefault();
-        bngApi.engineLua('extensions.load("fuelPriceEditor")');
+        var liquid = preferredLiquidUnit === 'imperial' ? 'gal' : 'L';
+        bngApi.engineLua(
+          'extensions.load("fuelPriceEditor") extensions.fuelPriceEditor.setLiquidUnit("' + liquid + '")'
+        );
       };
       $scope.unitModeLabels = {
         metric: 'Metric (L, km)',

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -115,7 +115,10 @@ describe('UI template styling', () => {
     controllerFn({ debug: () => {} }, $scope);
 
     $scope.openFuelPriceEditor({ preventDefault() {} });
-    assert.equal(luaCmd, 'extensions.load("fuelPriceEditor")');
+    assert.equal(
+      luaCmd,
+      'extensions.load("fuelPriceEditor") extensions.fuelPriceEditor.setLiquidUnit("L")'
+    );
   });
 
   it('persists style preference to localStorage', () => {


### PR DESCRIPTION
## Summary
- display fuel type units in Fuel Price Editor
- propagate liquid unit selection from UI
- update tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcf9fde6d48329b5d32732125375b2