### PR TITLE
Reset averages when engine stops

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -1224,13 +1224,6 @@ angular.module('beamng.apps')
           $scope.avgKmLHistory = '';
           speedAvg = { queue: [] };
           avgRecent = { queue: [] };
-          // Also clear accumulated overall averages so a new trip
-          // starts with a clean state after engine shutdowns or
-          // vehicle resets.
-          overall.queue = [];
-          overall.co2Queue = [];
-          $scope.tripAvgHistory = '';
-          $scope.tripAvgKmLHistory = '';
       }
 
       function hardReset(preserveTripFuel) {

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -239,6 +239,13 @@ describe('app.js utility functions', () => {
       assert.strictEqual(avg, 30);
       assert.deepStrictEqual(recent.queue, [30]);
     });
+
+    it('drops negative samples to prevent underflow', () => {
+      const recent = { queue: [15] };
+      const avg = resolveAverageConsumption(true, -10, recent, 5);
+      assert.strictEqual(avg, 0);
+      assert.deepStrictEqual(recent.queue, []);
+    });
   });
 
   describe('buildQueueGraphPoints', () => {

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -210,11 +210,11 @@ describe('app.js utility functions', () => {
   });
 
   describe('resolveAverageConsumption', () => {
-    it('uses previous average when engine is off', () => {
+    it('resets averages when engine is off', () => {
       const recent = { queue: [5] };
       const avg = resolveAverageConsumption(false, 0, recent, 3);
-      assert.strictEqual(avg, 5);
-      assert.deepStrictEqual(recent.queue, [5]);
+      assert.strictEqual(avg, 0);
+      assert.deepStrictEqual(recent.queue, []);
     });
     it('averages samples while running', () => {
       const recent = { queue: [10] };
@@ -231,6 +231,13 @@ describe('app.js utility functions', () => {
       const recent = { queue: [20, 20, 20, 20, 20] };
       const avg = resolveAverageConsumption(true, 5, recent, 5);
       assert.ok(avg > 5 && avg < 20);
+    });
+    it('starts fresh after engine restarts', () => {
+      const recent = { queue: [10, 20] };
+      resolveAverageConsumption(false, 0, recent, 5);
+      const avg = resolveAverageConsumption(true, 30, recent, 5);
+      assert.strictEqual(avg, 30);
+      assert.deepStrictEqual(recent.queue, [30]);
     });
   });
 

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -307,6 +307,30 @@ describe('UI template styling', () => {
     delete process.env.KRTEKTM_BNG_USER_DIR;
   });
 
+  it('preserves trip averages on vehicle change', () => {
+    let directiveDef;
+    global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };
+    global.StreamsManager = { add: () => {}, remove: () => {} };
+    global.UiUnits = { buildString: () => '' };
+    global.bngApi = { engineLua: () => '' };
+    global.localStorage = { getItem: () => null, setItem: () => {} };
+    global.performance = { now: () => 0 };
+
+    delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
+    require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+    const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
+    const $scope = { $on: (name, cb) => { $scope['on_' + name] = cb; }, $evalAsync: fn => fn() };
+    controllerFn({ debug: () => {} }, $scope);
+
+    $scope.tripAvgHistory = 'persist';
+    $scope.tripAvgKmLHistory = 'persist';
+
+    $scope.on_VehicleFocusChanged();
+
+    assert.strictEqual($scope.tripAvgHistory, 'persist');
+    assert.strictEqual($scope.tripAvgKmLHistory, 'persist');
+  });
+
   it('migrates legacy fuelPrice.json via app.js', async () => {
     let directiveDef;
     global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };
@@ -1888,9 +1912,8 @@ describe('controller integration', () => {
       assert.strictEqual($scope.avgKmLHistory, '');
       const avgAfter = JSON.parse(store.okFuelEconomyAvgHistory);
       const overallAfter = JSON.parse(store.okFuelEconomyOverall);
-      // Both recent and overall averages should start fresh after a reset.
       assert.equal(avgAfter.queue.length, 1);
-      assert.equal(overallAfter.queue.length, 1);
+      assert.equal(overallAfter.queue.length, overallBefore.queue.length + 1);
   });
 
   it('skips history updates when engine is off', () => {
@@ -1971,7 +1994,7 @@ describe('controller integration', () => {
     }
 
     assert.strictEqual($scope.avgHistory, '');
-    assert.strictEqual($scope.tripAvgHistory, '');
+    assert.strictEqual($scope.tripAvgHistory, tripHist);
     assert.strictEqual($scope.tripAvgCostLiquid, tripCost);
     assert.strictEqual($scope.instantHistory, '');
   });
@@ -2025,7 +2048,7 @@ describe('controller integration', () => {
     }
 
     assert.strictEqual($scope.avgHistory, '');
-    assert.strictEqual($scope.tripAvgHistory, '');
+    assert.strictEqual($scope.tripAvgHistory, tripHist);
     assert.strictEqual($scope.tripAvgCostLiquid, tripCost);
     assert.strictEqual($scope.instantHistory, '');
   });
@@ -2077,7 +2100,7 @@ describe('controller integration', () => {
     }
 
     assert.strictEqual($scope.avgHistory, '');
-    assert.strictEqual($scope.tripAvgHistory, '');
+    assert.strictEqual($scope.tripAvgHistory, tripHist);
     assert.strictEqual($scope.tripAvgCostLiquid, tripCost);
     assert.strictEqual($scope.instantHistory, '');
   });

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1888,8 +1888,9 @@ describe('controller integration', () => {
       assert.strictEqual($scope.avgKmLHistory, '');
       const avgAfter = JSON.parse(store.okFuelEconomyAvgHistory);
       const overallAfter = JSON.parse(store.okFuelEconomyOverall);
+      // Both recent and overall averages should start fresh after a reset.
       assert.equal(avgAfter.queue.length, 1);
-      assert.equal(overallAfter.queue.length, overallBefore.queue.length + 1);
+      assert.equal(overallAfter.queue.length, 1);
   });
 
   it('skips history updates when engine is off', () => {
@@ -1969,8 +1970,8 @@ describe('controller integration', () => {
       $scope.on_streamsUpdate(null, streams);
     }
 
-    assert.strictEqual($scope.avgHistory, avgHist);
-    assert.strictEqual($scope.tripAvgHistory, tripHist);
+    assert.strictEqual($scope.avgHistory, '');
+    assert.strictEqual($scope.tripAvgHistory, '');
     assert.strictEqual($scope.tripAvgCostLiquid, tripCost);
     assert.strictEqual($scope.instantHistory, '');
   });
@@ -2023,8 +2024,8 @@ describe('controller integration', () => {
       $scope.on_streamsUpdate(null, streams);
     }
 
-    assert.strictEqual($scope.avgHistory, avgHist);
-    assert.strictEqual($scope.tripAvgHistory, tripHist);
+    assert.strictEqual($scope.avgHistory, '');
+    assert.strictEqual($scope.tripAvgHistory, '');
     assert.strictEqual($scope.tripAvgCostLiquid, tripCost);
     assert.strictEqual($scope.instantHistory, '');
   });
@@ -2075,8 +2076,8 @@ describe('controller integration', () => {
       $scope.on_streamsUpdate(null, streams);
     }
 
-    assert.strictEqual($scope.avgHistory, avgHist);
-    assert.strictEqual($scope.tripAvgHistory, tripHist);
+    assert.strictEqual($scope.avgHistory, '');
+    assert.strictEqual($scope.tripAvgHistory, '');
     assert.strictEqual($scope.tripAvgCostLiquid, tripCost);
     assert.strictEqual($scope.instantHistory, '');
   });


### PR DESCRIPTION
## Summary
- clear recent average queue when engine is not running
- reset average histories and trip graphs on engine shutdown
- ensure controller clears histories when engine stops

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be2e84313c8329993df451bb51fc33