### PR TITLE
feat: add emission factors for additional fuel types

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -30,7 +30,24 @@ var CO2_FACTORS_G_PER_L = {
   Hydrogen: 0,
   Nitromethane: 820,
   Nitromethan: 820,
-  Food: 0.001 // approx. CO2 from human flatulence per kcal
+  Food: 0.001, // approx. CO2 from human flatulence per kcal
+  Kerosene: 2500,
+  'Jet Fuel': 2500,
+  Methanol: 1100,
+  Biodiesel: 2500,
+  Synthetic: 2392,
+  'Coal Gas': 2000,
+  Steam: 0,
+  Ammonia: 0,
+  Hybrid: 2392,
+  'Plug-in Hybrid': 2392,
+  'Fuel Oil': 3100,
+  'Heavy Oil': 3100,
+  Hydrazine: 0,
+  Hypergolic: 0,
+  'Solid Rocket': 1900,
+  'Black Powder': 1900,
+  ACPC: 1900
 };
 
 var NOX_FACTORS_G_PER_L = {
@@ -43,7 +60,24 @@ var NOX_FACTORS_G_PER_L = {
   Hydrogen: 0,
   Nitromethane: 12,
   Nitromethan: 12,
-  Food: 0
+  Food: 0,
+  Kerosene: 15,
+  'Jet Fuel': 15,
+  Methanol: 4,
+  Biodiesel: 18,
+  Synthetic: 10,
+  'Coal Gas': 15,
+  Steam: 0,
+  Ammonia: 6,
+  Hybrid: 10,
+  'Plug-in Hybrid': 10,
+  'Fuel Oil': 25,
+  'Heavy Oil': 25,
+  Hydrazine: 30,
+  Hypergolic: 30,
+  'Solid Rocket': 20,
+  'Black Powder': 20,
+  ACPC: 20
 };
 
 function resetFoodSimulation() {

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -409,6 +409,23 @@ describe('app.js utility functions', () => {
       assert.strictEqual(calculateCO2gPerKm(5, 'Nitromethane'), 5 / 100 * 820);
       assert.strictEqual(calculateCO2gPerKm(5, 'Nitromethan'), 5 / 100 * 820);
       assert.ok(Math.abs(calculateCO2gPerKm(5, 'Food') - 5 / 100 * 0.001) < 1e-9);
+      assert.strictEqual(calculateCO2gPerKm(5, 'Kerosene'), 5 / 100 * 2500);
+      assert.strictEqual(calculateCO2gPerKm(5, 'Jet Fuel'), 5 / 100 * 2500);
+      assert.strictEqual(calculateCO2gPerKm(5, 'Methanol'), 5 / 100 * 1100);
+      assert.strictEqual(calculateCO2gPerKm(5, 'Biodiesel'), 5 / 100 * 2500);
+      assert.strictEqual(calculateCO2gPerKm(5, 'Synthetic'), 5 / 100 * 2392);
+      assert.strictEqual(calculateCO2gPerKm(5, 'Coal Gas'), 5 / 100 * 2000);
+      assert.strictEqual(calculateCO2gPerKm(5, 'Steam'), 0);
+      assert.strictEqual(calculateCO2gPerKm(5, 'Ammonia'), 0);
+      assert.strictEqual(calculateCO2gPerKm(5, 'Hybrid'), 5 / 100 * 2392);
+      assert.strictEqual(calculateCO2gPerKm(5, 'Plug-in Hybrid'), 5 / 100 * 2392);
+      assert.strictEqual(calculateCO2gPerKm(5, 'Fuel Oil'), 5 / 100 * 3100);
+      assert.strictEqual(calculateCO2gPerKm(5, 'Heavy Oil'), 5 / 100 * 3100);
+      assert.strictEqual(calculateCO2gPerKm(5, 'Hydrazine'), 0);
+      assert.strictEqual(calculateCO2gPerKm(5, 'Hypergolic'), 0);
+      assert.strictEqual(calculateCO2gPerKm(5, 'Solid Rocket'), 5 / 100 * 1900);
+      assert.strictEqual(calculateCO2gPerKm(5, 'Black Powder'), 5 / 100 * 1900);
+      assert.strictEqual(calculateCO2gPerKm(5, 'ACPC'), 5 / 100 * 1900);
     });
     it('caps extreme consumption when computing emissions', () => {
       const capped = calculateCO2gPerKm(10000, 'Gasoline');
@@ -460,6 +477,10 @@ describe('app.js utility functions', () => {
       const boosted = calculateNOxFactor('Gasoline', 90, true, false);
       assert.ok(hot > base);
       assert.ok(boosted > base);
+    });
+    it('uses base NOx factors for additional fuels', () => {
+      assert.strictEqual(calculateNOxFactor('Ammonia', 90, false, false), 6);
+      assert.strictEqual(calculateNOxFactor('Fuel Oil', 90, false, false), 25);
     });
     it('returns zero for electric hydrogen drivetrains', () => {
       assert.strictEqual(calculateNOxFactor('Hydrogen', 200, false, true), 0);


### PR DESCRIPTION
## Summary
- include kerosene, methanol, biodiesel, synthetic and other fuels in CO2 and NOx factor tables
- test new fuel types for accurate emission calculations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bedc0f12248329a473e9bed62bd3d3