### PR TITLE
feat: detect game pause in fuel economy UI

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -3,7 +3,7 @@
      layout="column">
   <strong ng-if="visible.heading"
           ng-attr-style="{{ useCustomStyles ? 'display:block; margin:2px 0 4px; padding-left: 2px; font-size:1em; font-weight:600; color:#3fd6ff; text-shadow:0 0 5px rgba(0,255,255,0.6);' : '' }}">
-    Fuel Economy: {{ vehicleNameStr }}
+    Fuel Economy{{ gamePaused ? ' (game paused)' : '' }}: {{ vehicleNameStr }}
   </strong>
 
   <table ng-attr-style="{{ useCustomStyles ? 'width:100%; border-collapse:collapse; font-size:0.85em;' : '' }}">

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -747,8 +747,9 @@ angular.module('beamng.apps')
     scope: true,
     controller: ['$log', '$scope', '$timeout', function ($log, $scope, $timeout) {
       if (typeof $timeout !== 'function') $timeout = function (fn) { fn(); };
-      var streamsList = ['electrics', 'engineInfo'];
+      var streamsList = ['electrics', 'engineInfo', 'gameState'];
       StreamsManager.add(streamsList);
+      $scope.gamePaused = false;
 
         $scope.fuelPrices = { Gasoline: 0, Electricity: 0 };
         $scope.liquidFuelPriceValue = 0;
@@ -1538,6 +1539,13 @@ angular.module('beamng.apps')
 
       $scope.$on('streamsUpdate', function (event, streams) {
         $scope.$evalAsync(function () {
+          if (streams.gameState) {
+            if (typeof streams.gameState.paused === 'boolean') {
+              $scope.gamePaused = streams.gameState.paused;
+            } else if (typeof streams.gameState.state === 'string') {
+              $scope.gamePaused = streams.gameState.state.toLowerCase() !== 'playing';
+            }
+          }
           if ($scope.fuelType === 'Food') {
             fetchFuelType();
             if (!streams.electrics) return;


### PR DESCRIPTION
## Summary
- subscribe to BeamNG gameState stream to detect pause
- show "game paused" in Fuel Economy header when game is paused

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf378d16408329a17e3c9a025a961b