### PR TITLE
Add game pause detection to Fuel Economy widget

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -3,7 +3,7 @@
      layout="column">
   <strong ng-if="visible.heading"
           ng-attr-style="{{ useCustomStyles ? 'display:block; margin:2px 0 4px; padding-left: 2px; font-size:1em; font-weight:600; color:#3fd6ff; text-shadow:0 0 5px rgba(0,255,255,0.6);' : '' }}">
-    Fuel Economy: {{ vehicleNameStr }}
+    Fuel Economy<span ng-if="gamePaused"> (game paused)</span>: {{ vehicleNameStr }}
   </strong>
 
   <table ng-attr-style="{{ useCustomStyles ? 'width:100%; border-collapse:collapse; font-size:0.85em;' : '' }}">

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -750,6 +750,31 @@ angular.module('beamng.apps')
       var streamsList = ['electrics', 'engineInfo'];
       StreamsManager.add(streamsList);
 
+        $scope.gamePaused = false;
+
+        function detectGamePause() {
+          if (typeof bngApi === 'undefined') return;
+
+          if (bngApi.engine && typeof bngApi.engine.on === 'function') {
+            bngApi.engine.on('GameStateChanged', function (state) {
+              if (typeof state.paused !== 'undefined') {
+                $scope.$evalAsync(function () {
+                  $scope.gamePaused = state.paused;
+                });
+              }
+            });
+            bngApi.engine.on('GamePausedChanged', function (data) {
+              $scope.$evalAsync(function () {
+                $scope.gamePaused = data.paused;
+              });
+            });
+          }
+
+          // Initial state detection left to game events; no direct engineLua query
+        }
+
+        detectGamePause();
+
         $scope.fuelPrices = { Gasoline: 0, Electricity: 0 };
         $scope.liquidFuelPriceValue = 0;
         $scope.electricityPriceValue = 0;


### PR DESCRIPTION
## Summary
- detect BeamNG game pause via bngApi events
- show "(game paused)" in Fuel Economy heading when paused

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf369f25b483299f4e19ae259ee53f