### PR TITLE
Pause updates when game is paused

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -765,9 +765,15 @@ angular.module('beamng.apps')
             if (typeof $scope.$evalAsync === 'function') {
               $scope.$evalAsync(function () {
                 $scope.gamePaused = paused;
+                if (paused) {
+                  lastTime_ms = performance.now();
+                }
               });
             } else {
               $scope.gamePaused = paused;
+              if (paused) {
+                lastTime_ms = performance.now();
+              }
             }
           }
         );
@@ -1568,6 +1574,10 @@ angular.module('beamng.apps')
         $scope.$evalAsync(function () {
           if (streams.okGameState && typeof streams.okGameState.paused !== 'undefined') {
             $scope.gamePaused = !!streams.okGameState.paused;
+          }
+          if ($scope.gamePaused) {
+            lastTime_ms = performance.now();
+            return;
           }
           if ($scope.fuelType === 'Food') {
             fetchFuelType();


### PR DESCRIPTION
## Summary
- freeze widget calculations and graphs while the game is paused
- resume normal updates when gameplay continues

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf630c11e0832988f9796842e741db