### PR TITLE
Expose widget data through optional localhost endpoint

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -986,6 +986,12 @@
           <label><input type="checkbox" ng-model="visible.tripReset"> Trip reset</label>
         </div>
       </div>
+      <div class="setting-item" style="display:flex; align-items:center; margin-top:8px;">
+        <button id="endpointToggle" ng-click="toggleEndpoint()"
+                ng-attr-style="{{ 'font-size:0.8em; padding:2px 6px; cursor:pointer;' + (useCustomStyles ? ' color:#aeeaff; background:rgba(0,200,255,0.15); border:1px solid #5fdcff;' : 'color: #ff7722; border: 1px solid #ff7722;') }}">
+          {{ hostEnabled ? 'Disable' : 'Enable' }} Localhost Endpoint
+        </button>
+      </div>
     </div><br>
     <button id="settingsSaveButton" ng-click="saveSettings()"
             ng-attr-style="{{ 'margin-top:4px; font-size:0.8em; padding:2px 6px; cursor:pointer;' + (useCustomStyles ? ' color:#aeeaff; background:rgba(0,200,255,0.15); border:1px solid #5fdcff;' : 'color: #ff7722; border: 1px solid #ff7722;') }}">

--- a/tests/endpoint.test.js
+++ b/tests/endpoint.test.js
@@ -1,0 +1,44 @@
+const assert = require('node:assert');
+const { describe, it } = require('node:test');
+
+async function setupScope() {
+  let directiveDef;
+  global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };
+  global.StreamsManager = { add: () => {}, remove: () => {} };
+  global.UiUnits = { buildString: () => '' };
+  global.window = {};
+  global.bngApi = {
+    engineLua: (code, cb) => { if (cb) setTimeout(() => cb('{}'), 0); },
+    activeObjectLua: (code, cb) => setTimeout(() => cb('{}'), 0)
+  };
+  global.localStorage = { getItem: () => null, setItem: () => {} };
+  global.performance = { now: () => 0, markResourceTiming: () => {} };
+  delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
+  require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+  const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
+  const $scope = { $on: () => {}, $evalAsync: fn => fn() };
+  controllerFn({ debug: () => {} }, $scope);
+  await new Promise(r => setTimeout(r, 0));
+  $scope.heading = '0';
+  $scope.instantL100km = '0';
+  return $scope;
+}
+
+describe('localhost endpoint', () => {
+  it('serves app html and json data', async () => {
+    const $scope = await setupScope();
+    $scope.toggleEndpoint();
+
+    const htmlRes = await fetch('http://localhost:8099/');
+    const htmlText = await htmlRes.text();
+    assert.ok(htmlText.includes('<div class="bngApp"'));
+
+    const dataRes = await fetch('http://localhost:8099/data');
+    const json = await dataRes.json();
+    assert.ok('heading' in json);
+    assert.ok('instantL100km' in json);
+
+    $scope.toggleEndpoint();
+    await new Promise(r => setTimeout(r, 0));
+  });
+});


### PR DESCRIPTION
## Summary
- serve Fuel Economy widget UI and metrics through an optional localhost server
- add toggle in settings with stored preference
- cover new JSON/HTML endpoint with automated tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf63bb78f0832986a71a208c3e9f81