### PR TITLE
Allow Fuel Price Editor to be closed

### DIFF
--- a/okFuelEconomy/lua/ge/extensions/fuelPriceEditor.lua
+++ b/okFuelEconomy/lua/ge/extensions/fuelPriceEditor.lua
@@ -11,6 +11,9 @@ local uiState = {
   currency = im.ArrayChar(32, 'money')
 }
 
+local isOpen = false
+local openPtr = im.BoolPtr(false)
+
 local liquidUnit = 'L'
 
 local function unitLabel(name)
@@ -97,7 +100,12 @@ local function removeFuelType(name)
 end
 
 local function onUpdate()
-  im.Begin('Fuel Price Editor')
+  if not isOpen then return end
+  if not im.Begin('Fuel Price Editor', openPtr) then
+    im.End()
+    if not openPtr[0] then isOpen = false end
+    return
+  end
   local names = {}
   for name, _ in pairs(uiState.prices) do
     table.insert(names, name)
@@ -121,6 +129,7 @@ local function onUpdate()
   end
 
   im.End()
+  if not openPtr[0] then isOpen = false end
 end
 
 local function onExtensionLoaded()
@@ -137,6 +146,11 @@ end
 M.onUpdate = onUpdate
 M.onExtensionLoaded = onExtensionLoaded
 M.onFileChanged = onFileChanged
+
+function M.open()
+  openPtr[0] = true
+  isOpen = true
+end
 
 function M.setLiquidUnit(unit)
   if unit == 'gal' then

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -889,7 +889,7 @@ angular.module('beamng.apps')
         var liquid = preferredLiquidUnit === 'imperial' ? 'gal' : 'L';
         fuelPriceEditorLoaded = true;
         bngApi.engineLua(
-          'extensions.load("fuelPriceEditor") extensions.fuelPriceEditor.setLiquidUnit("' + liquid + '")'
+          'extensions.load("fuelPriceEditor") extensions.fuelPriceEditor.setLiquidUnit("' + liquid + '") extensions.fuelPriceEditor.open()'
         );
       };
       $scope.unitModeLabels = {

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -117,7 +117,7 @@ describe('UI template styling', () => {
     $scope.openFuelPriceEditor({ preventDefault() {} });
     assert.equal(
       luaCmd,
-      'extensions.load("fuelPriceEditor") extensions.fuelPriceEditor.setLiquidUnit("L")'
+      'extensions.load("fuelPriceEditor") extensions.fuelPriceEditor.setLiquidUnit("L") extensions.fuelPriceEditor.open()'
     );
   });
 


### PR DESCRIPTION
## Summary
- make Fuel Price Editor window closable and reopenable
- update UI controller to reopen editor with correct units
- adjust tests for new editor open command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfce57dc50832983285b6970ca0d8f