### PR TITLE
feat: support configurable emission factors

### DIFF
--- a/okFuelEconomy/lua/ge/extensions/fuelEmissionsEditor.lua
+++ b/okFuelEconomy/lua/ge/extensions/fuelEmissionsEditor.lua
@@ -40,6 +40,7 @@ local uiState = { emissions = {} }
 
 local isOpen = false
 local openPtr = im.BoolPtr(false)
+local FIELD_WIDTH = 80
 
 local function ensureFile()
   if not FS:directoryExists(emissionsDir) then
@@ -90,9 +91,17 @@ local function onUpdate()
   end
   table.sort(names)
   for _, name in ipairs(names) do
-    im.InputFloat(string.format('%s CO2 (g/L)##%sCO2', name, name), uiState.emissions[name].CO2)
+    im.Text(name .. ':')
     im.SameLine()
-    im.InputFloat(string.format('%s NOx (g/L)##%sNOx', name, name), uiState.emissions[name].NOx)
+    im.SetNextItemWidth(FIELD_WIDTH)
+    im.InputFloat('##' .. name .. 'CO2', uiState.emissions[name].CO2)
+    im.SameLine()
+    im.Text('CO2 g/L;')
+    im.SameLine()
+    im.SetNextItemWidth(FIELD_WIDTH)
+    im.InputFloat('##' .. name .. 'NOx', uiState.emissions[name].NOx)
+    im.SameLine()
+    im.Text('NOx g/L')
     im.SameLine()
     local disabled = name == 'Gasoline' or name == 'Electricity'
     if disabled then im.BeginDisabled() end

--- a/okFuelEconomy/lua/ge/extensions/fuelEmissionsEditor.lua
+++ b/okFuelEconomy/lua/ge/extensions/fuelEmissionsEditor.lua
@@ -1,0 +1,132 @@
+local M = {}
+
+local im = ui_imgui
+
+local emissionsPath = '/settings/krtektm_fuelEconomy/fuelEmissions.json'
+local emissionsDir = '/settings/krtektm_fuelEconomy/'
+
+local defaultEmissions = {
+  Gasoline = { CO2 = 2392, NOx = 10 },
+  Diesel = { CO2 = 2640, NOx = 20 },
+  ['LPG/CNG'] = { CO2 = 1660, NOx = 7 },
+  Electricity = { CO2 = 0, NOx = 0 },
+  Air = { CO2 = 0, NOx = 0 },
+  Ethanol = { CO2 = 1510, NOx = 3 },
+  Hydrogen = { CO2 = 0, NOx = 1 },
+  Nitromethane = { CO2 = 820, NOx = 12 },
+  Nitromethan = { CO2 = 820, NOx = 12 },
+  Food = { CO2 = 0.001, NOx = 0 },
+  Kerosene = { CO2 = 2500, NOx = 15 },
+  ['Jet Fuel'] = { CO2 = 2500, NOx = 15 },
+  Methanol = { CO2 = 1100, NOx = 4 },
+  Biodiesel = { CO2 = 2500, NOx = 18 },
+  Synthetic = { CO2 = 2392, NOx = 10 },
+  ['Coal Gas'] = { CO2 = 2000, NOx = 15 },
+  Steam = { CO2 = 0, NOx = 0 },
+  Ammonia = { CO2 = 0, NOx = 6 },
+  Hybrid = { CO2 = 2392, NOx = 10 },
+  ['Plug-in Hybrid'] = { CO2 = 2392, NOx = 10 },
+  ['Fuel Oil'] = { CO2 = 3100, NOx = 25 },
+  ['Heavy Oil'] = { CO2 = 3100, NOx = 25 },
+  Hydrazine = { CO2 = 0, NOx = 30 },
+  Hypergolic = { CO2 = 0, NOx = 30 },
+  ['Solid Rocket'] = { CO2 = 1900, NOx = 20 },
+  ['Black Powder'] = { CO2 = 1900, NOx = 20 },
+  ACPC = { CO2 = 1900, NOx = 20 }
+}
+
+local data = {}
+local uiState = { emissions = {} }
+
+local isOpen = false
+local openPtr = im.BoolPtr(false)
+
+local function ensureFile()
+  if not FS:directoryExists(emissionsDir) then
+    FS:directoryCreate(emissionsDir)
+  end
+  if not FS:fileExists(emissionsPath) then
+    jsonWriteFile(emissionsPath, defaultEmissions, true)
+  end
+end
+
+local function loadEmissions()
+  data = jsonReadFile(emissionsPath) or {}
+  uiState.emissions = {}
+  for k, v in pairs(data) do
+    uiState.emissions[k] = {
+      CO2 = im.FloatPtr(v.CO2 or 0),
+      NOx = im.FloatPtr(v.NOx or 0)
+    }
+  end
+end
+
+local function saveEmissions()
+  for k, v in pairs(uiState.emissions) do
+    data[k] = { CO2 = v.CO2[0], NOx = v.NOx[0] }
+  end
+  jsonWriteFile(emissionsPath, data, true)
+  loadEmissions()
+end
+
+local function removeFuelType(name)
+  if name == 'Gasoline' or name == 'Electricity' then return end
+  if uiState.emissions[name] == nil then return end
+  uiState.emissions[name] = nil
+  data[name] = nil
+  saveEmissions()
+end
+
+local function onUpdate()
+  if not isOpen then return end
+  if not im.Begin('Fuel Emissions Editor', openPtr) then
+    im.End()
+    if not openPtr[0] then isOpen = false end
+    return
+  end
+  local names = {}
+  for name, _ in pairs(uiState.emissions) do
+    table.insert(names, name)
+  end
+  table.sort(names)
+  for _, name in ipairs(names) do
+    im.InputFloat(string.format('%s CO2 (g/L)##%sCO2', name, name), uiState.emissions[name].CO2)
+    im.SameLine()
+    im.InputFloat(string.format('%s NOx (g/L)##%sNOx', name, name), uiState.emissions[name].NOx)
+    im.SameLine()
+    local disabled = name == 'Gasoline' or name == 'Electricity'
+    if disabled then im.BeginDisabled() end
+    if im.Button('Remove##' .. name) then
+      removeFuelType(name)
+    end
+    if disabled then im.EndDisabled() end
+  end
+  if im.Button('Save') then
+    saveEmissions()
+  end
+  im.End()
+  if not openPtr[0] then isOpen = false end
+end
+
+local function onExtensionLoaded()
+  ensureFile()
+  loadEmissions()
+end
+
+local function onFileChanged(path)
+  if path == emissionsPath then
+    loadEmissions()
+  end
+end
+
+M.onUpdate = onUpdate
+M.onExtensionLoaded = onExtensionLoaded
+M.onFileChanged = onFileChanged
+
+function M.open()
+  openPtr[0] = true
+  isOpen = true
+end
+
+return M
+

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -718,6 +718,12 @@
          ng-click="openFuelPriceEditor($event)"
          ng-attr-style="{{ useCustomStyles ? ' color:#aeeaff;' : '' }}">Open Fuel Price Editor</a>
     </p>
+    <p id="fuelEmissionsNotice"
+       ng-attr-style="{{ 'margin:4px 0;' + (useCustomStyles ? ' color:#aeeaff;' : '') }}">
+      <a href=""
+         ng-click="openFuelEmissionsEditor($event)"
+         ng-attr-style="{{ useCustomStyles ? ' color:#aeeaff;' : '' }}">Open Fuel Emissions Editor</a>
+    </p>
     <div ng-attr-style="{{ 'position:relative;' + (useCustomStyles ? '' : '') }}">
       <label>Units:
         <span ng-click="unitMenuOpen = !unitMenuOpen"

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -1063,8 +1063,10 @@ angular.module('beamng.apps')
       };
       $scope.openFuelEmissionsEditor = function ($event) {
         $event.preventDefault();
+        var liquid = preferredLiquidUnit === 'imperial' ? 'gal' : 'L';
+        fuelEmissionsEditorLoaded = true;
         bngApi.engineLua(
-          'extensions.load("fuelEmissionsEditor") extensions.fuelEmissionsEditor.open()'
+          'extensions.load("fuelEmissionsEditor") extensions.fuelEmissionsEditor.setLiquidUnit("' + liquid + '") extensions.fuelEmissionsEditor.open()'
         );
       };
       $scope.unitModeLabels = {
@@ -1084,6 +1086,7 @@ angular.module('beamng.apps')
           localStorage.getItem(PREFERRED_UNIT_KEY) ||
           ($scope.unitMode === 'imperial' ? 'imperial' : 'metric');
         var fuelPriceEditorLoaded = false;
+        var fuelEmissionsEditorLoaded = false;
         var manualUnit = false;
         var lastFuelType = '';
 
@@ -1095,10 +1098,15 @@ angular.module('beamng.apps')
           if (mode !== 'electric') {
             preferredLiquidUnit = mode;
             try { localStorage.setItem(PREFERRED_UNIT_KEY, preferredLiquidUnit); } catch (e) {}
+            var liquid = preferredLiquidUnit === 'imperial' ? 'gal' : 'L';
             if (fuelPriceEditorLoaded) {
-              var liquid = preferredLiquidUnit === 'imperial' ? 'gal' : 'L';
               bngApi.engineLua(
                 'extensions.fuelPriceEditor.setLiquidUnit("' + liquid + '")'
+              );
+            }
+            if (fuelEmissionsEditorLoaded) {
+              bngApi.engineLua(
+                'extensions.fuelEmissionsEditor.setLiquidUnit("' + liquid + '")'
               );
             }
           }

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -1061,6 +1061,12 @@ angular.module('beamng.apps')
           'extensions.load("fuelPriceEditor") extensions.fuelPriceEditor.setLiquidUnit("' + liquid + '") extensions.fuelPriceEditor.open()'
         );
       };
+      $scope.openFuelEmissionsEditor = function ($event) {
+        $event.preventDefault();
+        bngApi.engineLua(
+          'extensions.load("fuelEmissionsEditor") extensions.fuelEmissionsEditor.open()'
+        );
+      };
       $scope.unitModeLabels = {
         metric: 'Metric (L, km)',
         imperial: 'Imperial (gal, mi)',

--- a/tests/fuelEmissionsConfig.test.js
+++ b/tests/fuelEmissionsConfig.test.js
@@ -8,7 +8,7 @@ global.angular = { module: () => ({ directive: () => ({}) }) };
 const { loadFuelEmissionsConfig, ensureFuelEmissionType } = require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
 
 describe('fuel emissions config', () => {
-  it('creates, reloads and extends fuelEmissions.json', () => {
+  it('creates, reloads and extends fuelEmissions.json without redundant writes', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'em-'));
     const verDir = path.join(tmp, '1.0');
     fs.mkdirSync(verDir, { recursive: true });
@@ -21,15 +21,27 @@ describe('fuel emissions config', () => {
     assert.deepStrictEqual(saved1, cfg1);
     assert.strictEqual(cfg1.Diesel.CO2, 2640);
     assert.strictEqual(cfg1.Diesel.NOx, 20);
+    const m1 = fs.statSync(file).mtimeMs;
+    await new Promise(r => setTimeout(r, 20));
+    loadFuelEmissionsConfig();
+    const m2 = fs.statSync(file).mtimeMs;
+    assert.strictEqual(m2, m1);
 
     fs.unlinkSync(file);
     const cfg2 = loadFuelEmissionsConfig();
     const saved2 = JSON.parse(fs.readFileSync(file, 'utf8'));
     assert.deepStrictEqual(saved2, cfg2);
 
+    const m3 = fs.statSync(file).mtimeMs;
+    await new Promise(r => setTimeout(r, 20));
     ensureFuelEmissionType('Unobtanium');
-    const saved3 = JSON.parse(fs.readFileSync(file, 'utf8'));
-    assert.strictEqual(saved3.Unobtanium.CO2, 0);
-    assert.strictEqual(saved3.Unobtanium.NOx, 0);
+    const m4 = fs.statSync(file).mtimeMs;
+    assert.ok(m4 > m3);
+    await new Promise(r => setTimeout(r, 20));
+    ensureFuelEmissionType('Unobtanium');
+    const m5 = fs.statSync(file).mtimeMs;
+    assert.strictEqual(m5, m4);
+
+    delete process.env.KRTEKTM_BNG_USER_DIR;
   });
 });

--- a/tests/fuelEmissionsConfig.test.js
+++ b/tests/fuelEmissionsConfig.test.js
@@ -19,8 +19,8 @@ describe('fuel emissions config', () => {
     assert.ok(fs.existsSync(file));
     const saved1 = JSON.parse(fs.readFileSync(file, 'utf8'));
     assert.deepStrictEqual(saved1, cfg1);
-    assert.strictEqual(cfg1.CO2.Diesel, 2640);
-    assert.strictEqual(cfg1.NOx.Diesel, 20);
+    assert.strictEqual(cfg1.Diesel.CO2, 2640);
+    assert.strictEqual(cfg1.Diesel.NOx, 20);
 
     fs.unlinkSync(file);
     const cfg2 = loadFuelEmissionsConfig();
@@ -29,7 +29,7 @@ describe('fuel emissions config', () => {
 
     ensureFuelEmissionType('Unobtanium');
     const saved3 = JSON.parse(fs.readFileSync(file, 'utf8'));
-    assert.strictEqual(saved3.CO2.Unobtanium, 0);
-    assert.strictEqual(saved3.NOx.Unobtanium, 0);
+    assert.strictEqual(saved3.Unobtanium.CO2, 0);
+    assert.strictEqual(saved3.Unobtanium.NOx, 0);
   });
 });

--- a/tests/fuelEmissionsConfig.test.js
+++ b/tests/fuelEmissionsConfig.test.js
@@ -19,6 +19,8 @@ describe('fuel emissions config', () => {
     assert.ok(fs.existsSync(file));
     const saved1 = JSON.parse(fs.readFileSync(file, 'utf8'));
     assert.deepStrictEqual(saved1, cfg1);
+    assert.strictEqual(cfg1.CO2.Diesel, 2640);
+    assert.strictEqual(cfg1.NOx.Diesel, 20);
 
     fs.unlinkSync(file);
     const cfg2 = loadFuelEmissionsConfig();

--- a/tests/fuelEmissionsConfig.test.js
+++ b/tests/fuelEmissionsConfig.test.js
@@ -1,0 +1,33 @@
+const assert = require('node:assert');
+const { describe, it } = require('node:test');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+global.angular = { module: () => ({ directive: () => ({}) }) };
+const { loadFuelEmissionsConfig, ensureFuelEmissionType } = require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+
+describe('fuel emissions config', () => {
+  it('creates, reloads and extends fuelEmissions.json', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'em-'));
+    const verDir = path.join(tmp, '1.0');
+    fs.mkdirSync(verDir, { recursive: true });
+    process.env.KRTEKTM_BNG_USER_DIR = tmp;
+
+    const cfg1 = loadFuelEmissionsConfig();
+    const file = loadFuelEmissionsConfig.userFile;
+    assert.ok(fs.existsSync(file));
+    const saved1 = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert.deepStrictEqual(saved1, cfg1);
+
+    fs.unlinkSync(file);
+    const cfg2 = loadFuelEmissionsConfig();
+    const saved2 = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert.deepStrictEqual(saved2, cfg2);
+
+    ensureFuelEmissionType('Unobtanium');
+    const saved3 = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert.strictEqual(saved3.CO2.Unobtanium, 0);
+    assert.strictEqual(saved3.NOx.Unobtanium, 0);
+  });
+});

--- a/tests/fuelEmissionsEditor.test.js
+++ b/tests/fuelEmissionsEditor.test.js
@@ -143,7 +143,9 @@ describe('Fuel Emissions Editor ordering', () => {
   it('lists fuel types alphabetically', () => {
     const order = [];
     const im = {
-      InputFloat: name => order.push(name),
+      Text: () => {},
+      SetNextItemWidth: () => {},
+      InputFloat: label => order.push(label),
       SameLine: () => {},
       BeginDisabled: () => {},
       EndDisabled: () => {},
@@ -160,9 +162,17 @@ describe('Fuel Emissions Editor ordering', () => {
     function onUpdate() {
       const names = Object.keys(uiState.emissions).sort();
       names.forEach(name => {
-        im.InputFloat(name + ' CO2', uiState.emissions[name].CO2);
+        im.Text(name + ':');
         im.SameLine();
-        im.InputFloat(name + ' NOx', uiState.emissions[name].NOx);
+        im.SetNextItemWidth();
+        im.InputFloat('##' + name + 'CO2', uiState.emissions[name].CO2);
+        im.SameLine();
+        im.Text('CO2 g/L;');
+        im.SameLine();
+        im.SetNextItemWidth();
+        im.InputFloat('##' + name + 'NOx', uiState.emissions[name].NOx);
+        im.SameLine();
+        im.Text('NOx g/L');
         im.SameLine();
         const disabled = name === 'Gasoline' || name === 'Electricity';
         if (disabled) im.BeginDisabled();
@@ -173,12 +183,12 @@ describe('Fuel Emissions Editor ordering', () => {
 
     onUpdate();
     assert.deepStrictEqual(order, [
-      'Diesel CO2',
-      'Diesel NOx',
-      'Electricity CO2',
-      'Electricity NOx',
-      'Gasoline CO2',
-      'Gasoline NOx'
+      '##DieselCO2',
+      '##DieselNOx',
+      '##ElectricityCO2',
+      '##ElectricityNOx',
+      '##GasolineCO2',
+      '##GasolineNOx'
     ]);
   });
 });

--- a/tests/fuelEmissionsEditor.test.js
+++ b/tests/fuelEmissionsEditor.test.js
@@ -1,0 +1,184 @@
+const assert = require('node:assert');
+const { describe, it } = require('node:test');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+describe('Fuel Emissions Editor saving', () => {
+  it('saves edited emissions to fuelEmissions.json', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'emedit-'));
+    const map = p => path.join(tmp, p.replace(/^\//, ''));
+
+    const emPath = '/settings/krtektm_fuelEconomy/fuelEmissions.json';
+    const emDir = '/settings/krtektm_fuelEconomy/';
+
+    const data = {};
+    const uiState = { emissions: {} };
+
+    const FS = {
+      directoryExists: p => fs.existsSync(map(p)),
+      directoryCreate: p => fs.mkdirSync(map(p), { recursive: true }),
+      fileExists: p => fs.existsSync(map(p))
+    };
+
+    const jsonWriteFile = (p, tbl) => fs.writeFileSync(map(p), JSON.stringify(tbl));
+    const jsonReadFile = p => JSON.parse(fs.readFileSync(map(p), 'utf8'));
+
+    function ensureFile() {
+      if (!FS.directoryExists(emDir)) FS.directoryCreate(emDir);
+      if (!FS.fileExists(emPath)) {
+        jsonWriteFile(emPath, {
+          Gasoline: { CO2: 2392, NOx: 10 },
+          Electricity: { CO2: 0, NOx: 0 }
+        });
+      }
+    }
+
+    function loadEmissions() {
+      const read = jsonReadFile(emPath);
+      Object.assign(data, read);
+      uiState.emissions = {};
+      Object.keys(read).forEach(k => {
+        uiState.emissions[k] = {
+          CO2: { 0: read[k].CO2 },
+          NOx: { 0: read[k].NOx }
+        };
+      });
+    }
+
+    function saveEmissions() {
+      const out = {};
+      Object.keys(uiState.emissions).forEach(k => {
+        out[k] = {
+          CO2: uiState.emissions[k].CO2[0],
+          NOx: uiState.emissions[k].NOx[0]
+        };
+      });
+      for (const k of Object.keys(data)) delete data[k];
+      Object.assign(data, out);
+      jsonWriteFile(emPath, data);
+      loadEmissions();
+    }
+
+    ensureFile();
+    loadEmissions();
+    uiState.emissions.Gasoline.CO2[0] = 2500;
+    uiState.emissions.Gasoline.NOx[0] = 11;
+    saveEmissions();
+
+    const saved = jsonReadFile(emPath);
+    assert.deepStrictEqual(saved, {
+      Gasoline: { CO2: 2500, NOx: 11 },
+      Electricity: { CO2: 0, NOx: 0 }
+    });
+  });
+});
+
+describe('Fuel Emissions Editor removal', () => {
+  it('removes fuel types from fuelEmissions.json', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'emedit-'));
+    const map = p => path.join(tmp, p.replace(/^\//, ''));
+
+    const emPath = '/settings/krtektm_fuelEconomy/fuelEmissions.json';
+    fs.mkdirSync(path.dirname(map(emPath)), { recursive: true });
+    fs.writeFileSync(
+      map(emPath),
+      JSON.stringify({
+        Gasoline: { CO2: 1, NOx: 2 },
+        Electricity: { CO2: 0, NOx: 0 },
+        Diesel: { CO2: 3, NOx: 4 }
+      })
+    );
+
+    const data = {};
+    const uiState = { emissions: {} };
+
+    const jsonWriteFile = (p, tbl) => fs.writeFileSync(map(p), JSON.stringify(tbl));
+    const jsonReadFile = p => JSON.parse(fs.readFileSync(map(p), 'utf8'));
+
+    function loadEmissions() {
+      const read = jsonReadFile(emPath);
+      Object.assign(data, read);
+      uiState.emissions = {};
+      Object.keys(read).forEach(k => {
+        uiState.emissions[k] = {
+          CO2: { 0: read[k].CO2 },
+          NOx: { 0: read[k].NOx }
+        };
+      });
+    }
+
+    function saveEmissions() {
+      const out = {};
+      Object.keys(uiState.emissions).forEach(k => {
+        out[k] = {
+          CO2: uiState.emissions[k].CO2[0],
+          NOx: uiState.emissions[k].NOx[0]
+        };
+      });
+      for (const k of Object.keys(data)) delete data[k];
+      Object.assign(data, out);
+      jsonWriteFile(emPath, data);
+      loadEmissions();
+    }
+
+    function removeFuelType(name) {
+      if (name === 'Gasoline' || name === 'Electricity') return;
+      delete uiState.emissions[name];
+      saveEmissions();
+    }
+
+    loadEmissions();
+    removeFuelType('Diesel');
+
+    const saved = jsonReadFile(emPath);
+    assert.deepStrictEqual(saved, {
+      Gasoline: { CO2: 1, NOx: 2 },
+      Electricity: { CO2: 0, NOx: 0 }
+    });
+  });
+});
+
+describe('Fuel Emissions Editor ordering', () => {
+  it('lists fuel types alphabetically', () => {
+    const order = [];
+    const im = {
+      InputFloat: name => order.push(name),
+      SameLine: () => {},
+      BeginDisabled: () => {},
+      EndDisabled: () => {},
+      Button: () => {}
+    };
+    const uiState = {
+      emissions: {
+        Gasoline: { CO2: {}, NOx: {} },
+        Diesel: { CO2: {}, NOx: {} },
+        Electricity: { CO2: {}, NOx: {} }
+      }
+    };
+
+    function onUpdate() {
+      const names = Object.keys(uiState.emissions).sort();
+      names.forEach(name => {
+        im.InputFloat(name + ' CO2', uiState.emissions[name].CO2);
+        im.SameLine();
+        im.InputFloat(name + ' NOx', uiState.emissions[name].NOx);
+        im.SameLine();
+        const disabled = name === 'Gasoline' || name === 'Electricity';
+        if (disabled) im.BeginDisabled();
+        im.Button('Remove##' + name);
+        if (disabled) im.EndDisabled();
+      });
+    }
+
+    onUpdate();
+    assert.deepStrictEqual(order, [
+      'Diesel CO2',
+      'Diesel NOx',
+      'Electricity CO2',
+      'Electricity NOx',
+      'Gasoline CO2',
+      'Gasoline NOx'
+    ]);
+  });
+});

--- a/tests/fuelPriceConfig.test.js
+++ b/tests/fuelPriceConfig.test.js
@@ -1,0 +1,29 @@
+const assert = require('node:assert');
+const { describe, it } = require('node:test');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+global.angular = { module: () => ({ directive: () => ({}) }) };
+const { loadFuelPriceConfig } = require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+
+describe('fuel price config', () => {
+  it('does not rewrite fuelPrice.json when unchanged', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'fp-'));
+    const verDir = path.join(tmp, '1.0');
+    fs.mkdirSync(verDir, { recursive: true });
+    const prev = process.env.KRTEKTM_BNG_USER_DIR;
+    process.env.KRTEKTM_BNG_USER_DIR = tmp;
+
+    loadFuelPriceConfig();
+    const file = loadFuelPriceConfig.userFile;
+    const m1 = fs.statSync(file).mtimeMs;
+    await new Promise(r => setTimeout(r, 20));
+    loadFuelPriceConfig();
+    const m2 = fs.statSync(file).mtimeMs;
+    assert.strictEqual(m2, m1);
+
+    if (prev === undefined) delete process.env.KRTEKTM_BNG_USER_DIR;
+    else process.env.KRTEKTM_BNG_USER_DIR = prev;
+  });
+});

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -62,6 +62,7 @@ describe('UI template styling', () => {
     assert.ok(!html.includes('fetch('));
     assert.ok(html.includes('fuelPriceNotice'));
     assert.ok(html.includes('Open Fuel Price Editor'));
+    assert.ok(html.includes('Open Fuel Emissions Editor'));
     assert.ok(!html.includes('<script type="text/javascript">'));
     assert.ok(html.includes('{{ costPrice }}'));
     assert.ok(html.includes('{{ avgCost }}'));
@@ -118,6 +119,29 @@ describe('UI template styling', () => {
     assert.equal(
       luaCmd,
       'extensions.load("fuelPriceEditor") extensions.fuelPriceEditor.setLiquidUnit("L") extensions.fuelPriceEditor.open()'
+    );
+  });
+
+  it('loads fuel emissions editor via controller function', async () => {
+    let directiveDef;
+    let luaCmd;
+    global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };
+    global.StreamsManager = { add: () => {}, remove: () => {} };
+    global.UiUnits = { buildString: () => '' };
+    global.window = {};
+    global.bngApi = { engineLua: cmd => { luaCmd = cmd; } };
+    global.localStorage = { getItem: () => null, setItem: () => {} };
+    global.performance = { now: () => 0 };
+    delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
+    require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+    const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
+    const $scope = { $on: () => {} };
+    controllerFn({ debug: () => {} }, $scope);
+
+    $scope.openFuelEmissionsEditor({ preventDefault() {} });
+    assert.equal(
+      luaCmd,
+      'extensions.load("fuelEmissionsEditor") extensions.fuelEmissionsEditor.open()'
     );
   });
 

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -141,7 +141,7 @@ describe('UI template styling', () => {
     $scope.openFuelEmissionsEditor({ preventDefault() {} });
     assert.equal(
       luaCmd,
-      'extensions.load("fuelEmissionsEditor") extensions.fuelEmissionsEditor.open()'
+      'extensions.load("fuelEmissionsEditor") extensions.fuelEmissionsEditor.setLiquidUnit("L") extensions.fuelEmissionsEditor.open()'
     );
   });
 
@@ -182,13 +182,16 @@ describe('UI template styling', () => {
     controllerFn({ debug: () => {} }, $scope);
 
     $scope.openFuelPriceEditor({ preventDefault() {} });
+    $scope.openFuelEmissionsEditor({ preventDefault() {} });
     cmds.length = 0;
     $scope.setUnit('imperial');
     $scope.setUnit('metric');
 
     assert.deepStrictEqual(cmds, [
       'extensions.fuelPriceEditor.setLiquidUnit("gal")',
-      'extensions.fuelPriceEditor.setLiquidUnit("L")'
+      'extensions.fuelEmissionsEditor.setLiquidUnit("gal")',
+      'extensions.fuelPriceEditor.setLiquidUnit("L")',
+      'extensions.fuelEmissionsEditor.setLiquidUnit("L")'
     ]);
   });
 


### PR DESCRIPTION
## Summary
- load CO2 and NOx factors from a user fuelEmissions.json and refresh them periodically
- populate missing fuels with zeroed emission factors and recreate config if deleted
- cover emission configuration behavior with automated tests
- read emission factors solely from user settings directory instead of a bundled JSON

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e50f646483299481967f7fff1efa