### PR TITLE
Fix Fuel Price Editor input width

### DIFF
--- a/okFuelEconomy/lua/ge/extensions/fuelPriceEditor.lua
+++ b/okFuelEconomy/lua/ge/extensions/fuelPriceEditor.lua
@@ -124,6 +124,7 @@ local function onUpdate()
     end
     if disabled then im.EndDisabled() end
   end
+  im.SetNextItemWidth(FIELD_WIDTH)
   im.InputText('Currency', uiState.currency)
 
   if im.Button('Save') then

--- a/tests/fuelPriceEditor.test.js
+++ b/tests/fuelPriceEditor.test.js
@@ -206,6 +206,7 @@ describe('Fuel Price Editor ordering', () => {
     function onUpdate() {
       const names = Object.keys(uiState.prices).sort();
       names.forEach(name => {
+        im.SetNextItemWidth(80);
         im.InputFloat(name, uiState.prices[name]);
         im.SameLine();
         const disabled = name === 'Gasoline' || name === 'Electricity';
@@ -214,6 +215,7 @@ describe('Fuel Price Editor ordering', () => {
         im.Button(label);
         if (disabled) im.EndDisabled();
       });
+      im.SetNextItemWidth(80);
       im.InputText('Currency', uiState.currency);
     }
 


### PR DESCRIPTION
## Summary
- Keep fuel price input fields fixed at 80px width
- Update tests to account for width setting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c21df3bb8083299fb8bfb3465149d0