### PR TITLE
fix: enforce menu stacking

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -730,7 +730,7 @@
               ng-attr-style="{{ 'cursor:pointer; text-decoration:underline;' + (useCustomStyles ? ' color:#aeeaff;' : '') }}">{{ unitModeLabels[unitMode] }}</span>
       </label>
       <ul ng-if="unitMenuOpen"
-          ng-attr-style="{{ 'list-style:none; margin:2px 0 0; padding:0; position:absolute; right:0; background:rgba(0,0,0,0.9); border:1px solid;' + (useCustomStyles ? ' border-color:#5fdcff; color:#aeeaff;' : ' border-color:#ccc; color:#fff;') }}">
+          ng-attr-style="{{ 'list-style:none; margin:2px 0 0; padding:0; position:absolute; right:0; z-index:1000; background:#000; border:1px solid;' + (useCustomStyles ? ' border-color:#5fdcff; color:#aeeaff;' : ' border-color:#ccc; color:#fff;') }}">
         <li ng-repeat="(value,label) in unitModeOptions"
             ng-click="setUnit(value)"
             ng-attr-style="{{ 'padding:2px 6px; cursor:pointer;' + (useCustomStyles ? ' background:rgba(0,200,255,0.15);' : '') }}">{{ label }}</li>
@@ -743,7 +743,7 @@
                 ng-attr-style="{{ 'cursor:pointer; text-decoration:underline;' + (useCustomStyles ? ' color:#aeeaff;' : '') }}">{{ avgConsumptionAlgorithmLabels[avgConsumptionAlgorithm] }}</span>
         </label>
         <ul ng-if="avgConsumptionAlgorithmMenuOpen"
-            ng-attr-style="{{ 'list-style:none; margin:2px 0 0; padding:0; position:absolute; right:0; background:rgba(0,0,0,0.9); border:1px solid;' + (useCustomStyles ? ' border-color:#5fdcff; color:#aeeaff;' : ' border-color:#ccc; color:#fff;') }}">
+            ng-attr-style="{{ 'list-style:none; margin:2px 0 0; padding:0; position:absolute; right:0; z-index:1000; background:#000; border:1px solid;' + (useCustomStyles ? ' border-color:#5fdcff; color:#aeeaff;' : ' border-color:#ccc; color:#fff;') }}">
           <li ng-repeat="(value,label) in avgConsumptionAlgorithmOptions"
               ng-click="setAvgConsumptionAlgorithm(value)"
               ng-attr-style="{{ 'padding:2px 6px; cursor:pointer;' + (useCustomStyles ? ' background:rgba(0,200,255,0.15);' : '') }}">{{ label }}</li>


### PR DESCRIPTION
## Summary
- ensure unit and algorithm dropdown menus stack above other settings
- switch dropdown backgrounds to solid black for reliable clicks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c373e855e48329b6b938eb7e2887da