### PR TITLE
Fix electric instant efficiency when ignition off

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -2406,6 +2406,8 @@ angular.module('beamng.apps')
           var eff =
             Number.isFinite(inst_l_per_100km) && inst_l_per_100km > 0
               ? 100 / inst_l_per_100km
+              : Math.abs(speed_mps) <= EPS_SPEED
+              ? 0
               : MAX_EFFICIENCY;
           eff = Math.min(eff, MAX_EFFICIENCY);
           if (now_ms - lastInstantUpdate_ms >= INSTANT_UPDATE_INTERVAL) {

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -2343,6 +2343,7 @@ describe('controller integration', () => {
       $scope.on_streamsUpdate(null, streams);
     }
 
+    assert.strictEqual($scope.instantKmL, '0.00 km/kWh');
     assert.strictEqual($scope.instantHistory, '');
   });
 


### PR DESCRIPTION
## Summary
- avoid showing 100 km/kWh when stationary with electric ignition off
- cover stationary electric ignition off case in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c37ea88868832987a66a78f5564082