### PR TITLE
Fix row visibility handling and add regression tests

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -1021,6 +1021,6 @@
             ng-attr-style="{{ 'margin-top:4px; font-size:0.8em; padding:2px 6px; cursor:pointer;' + (useCustomStyles ? ' color:#aeeaff; background:rgba(0,200,255,0.15); border:1px solid #5fdcff;' : 'color: #ff7722; border: 1px solid #ff7722;') }}">
       <span class="material-icons" ng-attr-style="{{ 'font-size:inherit; vertical-align:middle; margin-right:2px;' + (useCustomStyles ? '' : '') }}">save</span>Save
     </button><br><br>
-      <p ng-attr-style="{{ useCustomStyles ? 'margin-top:4px; color:#aeeaff; font-size: 11px; font-style: italic;' : '' }}">Fuel Economy v1.0.11</p>
+      <p ng-attr-style="{{ useCustomStyles ? 'margin-top:4px; color:#aeeaff; font-size: 11px; font-style: italic;' : '' }}">Fuel Economy v1.0.12</p>
     </div>
   </div>

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -1191,6 +1191,9 @@ angular.module('beamng.apps')
         StreamsManager.remove(streamsList);
         clearInterval(priceTimer);
         clearInterval(emissionsTimer);
+        if (rowObserver && typeof rowObserver.disconnect === 'function') {
+          rowObserver.disconnect();
+        }
       });
 
       // Settings for visible fields
@@ -1199,6 +1202,127 @@ angular.module('beamng.apps')
       var STYLE_KEY = 'okFuelEconomyUseCustomStyles';
       var PREFERRED_UNIT_KEY = 'okFuelEconomyPreferredUnit';
       var ROW_ORDER_KEY = 'okFeRowOrder';
+      var rowOrder = [];
+      var defaultRowOrder = [];
+      var rowObserver = null;
+      var applyingRowOrder = false;
+      try {
+        var storedRowOrder = JSON.parse(localStorage.getItem(ROW_ORDER_KEY));
+        if (Array.isArray(storedRowOrder)) rowOrder = storedRowOrder.slice();
+      } catch (e) {
+        rowOrder = [];
+      }
+
+      function ensureDefaultOrder() {
+        if (defaultRowOrder.length || typeof document === 'undefined') return;
+        var settingsList = document.getElementById('settingsList');
+        if (settingsList && settingsList.children) {
+          defaultRowOrder = Array.prototype.slice
+            .call(settingsList.children)
+            .map(function (item) {
+              return item.getAttribute('data-row');
+            })
+            .filter(Boolean);
+        } else {
+          var tbody = document.getElementById('dataRows');
+          if (tbody && tbody.children) {
+            defaultRowOrder = Array.prototype.slice
+              .call(tbody.children)
+              .map(function (row) {
+                return row && row.id;
+              })
+              .filter(Boolean);
+          }
+        }
+      }
+
+      function mergeRowOrder(existing) {
+        ensureDefaultOrder();
+        var allowed = defaultRowOrder;
+        if (!allowed.length) {
+          return Array.isArray(existing) ? existing.slice() : [];
+        }
+        var merged = [];
+        if (Array.isArray(existing)) {
+          existing.forEach(function (id) {
+            if (id && allowed.indexOf(id) !== -1 && merged.indexOf(id) === -1) {
+              merged.push(id);
+            }
+          });
+        }
+        allowed.forEach(function (id) {
+          if (merged.indexOf(id) === -1) merged.push(id);
+        });
+        return merged;
+      }
+
+      function persistRowOrder() {
+        try {
+          localStorage.setItem(ROW_ORDER_KEY, JSON.stringify(rowOrder));
+        } catch (e) { /* ignore */ }
+        sendWebData();
+      }
+
+      function applyRowOrder() {
+        if (typeof document === 'undefined') return false;
+        var merged = mergeRowOrder(rowOrder);
+        var changed =
+          merged.length !== rowOrder.length ||
+          merged.some(function (id, idx) { return id !== rowOrder[idx]; });
+        rowOrder = merged;
+
+        var tbody = document.getElementById('dataRows');
+        if (tbody) {
+          applyingRowOrder = true;
+          try {
+            rowOrder.forEach(function (id) {
+              var rowEl = document.getElementById(id);
+              if (rowEl && rowEl.parentElement === tbody) {
+                tbody.appendChild(rowEl);
+              }
+            });
+          } finally {
+            applyingRowOrder = false;
+          }
+        }
+
+        var settingsList = document.getElementById('settingsList');
+        if (settingsList && settingsList.children) {
+          var settingsChildren = Array.prototype.slice.call(settingsList.children);
+          var settingsMap = {};
+          settingsChildren.forEach(function (item) {
+            var key = item && typeof item.getAttribute === 'function'
+              ? item.getAttribute('data-row')
+              : null;
+            if (key) settingsMap[key] = item;
+          });
+          rowOrder.forEach(function (id) {
+            var item = settingsMap[id];
+            if (item) settingsList.appendChild(item);
+          });
+        }
+
+        return changed;
+      }
+
+      function setupRowObserver() {
+        if (
+          typeof document === 'undefined' ||
+          typeof MutationObserver !== 'function'
+        ) {
+          return;
+        }
+        var tbody = document.getElementById('dataRows');
+        if (!tbody) return;
+        if (rowObserver && typeof rowObserver.disconnect === 'function') {
+          rowObserver.disconnect();
+        }
+        rowObserver = new MutationObserver(function () {
+          if (applyingRowOrder) return;
+          applyRowOrder();
+        });
+        rowObserver.observe(tbody, { childList: true });
+      }
       $scope.useCustomStyles = localStorage.getItem(STYLE_KEY) !== 'false';
       $scope.toggleCustomStyles = function () {
         $scope.useCustomStyles = !$scope.useCustomStyles;
@@ -1545,59 +1669,27 @@ angular.module('beamng.apps')
         $scope.settingsOpen = false;
       };
 
-      function saveRowOrder() {
-        var tbody = document.getElementById('dataRows');
-        if (!tbody) return;
-        var order = Array.prototype.map.call(tbody.children, function (r) { return r.id; });
-        try { localStorage.setItem(ROW_ORDER_KEY, JSON.stringify(order)); } catch (e) {}
-        sendWebData();
-      }
-
       $scope.moveRow = function ($event, dir) {
         var item = $event.target.closest('.setting-item');
         if (!item) return;
         var rowId = item.getAttribute('data-row');
-        var tbody = document.getElementById('dataRows');
-        var settingsList = document.getElementById('settingsList');
-        var row = document.getElementById(rowId);
-        if (!row || !tbody || !settingsList) return;
-        if (dir < 0) {
-          var prevRow = row.previousElementSibling;
-          var prevItem = item.previousElementSibling;
-          if (prevRow && prevItem) {
-            tbody.insertBefore(row, prevRow);
-            settingsList.insertBefore(item, prevItem);
-          }
-        } else {
-          var nextRow = row.nextElementSibling;
-          var nextItem = item.nextElementSibling;
-          if (nextRow && nextItem) {
-            tbody.insertBefore(nextRow, row);
-            settingsList.insertBefore(nextItem, item);
-          }
-        }
-        saveRowOrder();
+        rowOrder = mergeRowOrder(rowOrder);
+        var idx = rowOrder.indexOf(rowId);
+        if (idx === -1) return;
+        var targetIndex = idx + (dir < 0 ? -1 : 1);
+        if (targetIndex < 0 || targetIndex >= rowOrder.length) return;
+        var moved = rowOrder.splice(idx, 1)[0];
+        rowOrder.splice(targetIndex, 0, moved);
+        applyRowOrder();
+        persistRowOrder();
       };
-
-        function loadRowOrder() {
-          if (typeof document === 'undefined') return;
-          var order;
-          try { order = JSON.parse(localStorage.getItem(ROW_ORDER_KEY)); } catch (e) { order = null; }
-          if (!Array.isArray(order)) return;
-          var tbody = document.getElementById('dataRows');
-          var settingsList = document.getElementById('settingsList');
-          if (!tbody || !settingsList) return;
-          var rows = {};
-          Array.prototype.forEach.call(tbody.children, function (r) { rows[r.id] = r; });
-          var settings = {};
-          Array.prototype.forEach.call(settingsList.children, function (s) { settings[s.getAttribute('data-row')] = s; });
-          order.forEach(function (id) {
-            if (rows[id]) tbody.appendChild(rows[id]);
-            if (settings[id]) settingsList.appendChild(settings[id]);
-          });
-        }
-
-        $timeout(loadRowOrder, 0);
+        $timeout(function () {
+          var changed = applyRowOrder();
+          setupRowObserver();
+          if (changed) {
+            persistRowOrder();
+          }
+        }, 0);
 
       // UI outputs
       $scope.data1 = ''; // distance measured
@@ -2088,8 +2180,8 @@ angular.module('beamng.apps')
 
       function sendWebData() {
         if ($scope.webEndpointRunning && bngApi && typeof bngApi.engineLua === 'function') {
-          var rowOrder;
-          try { rowOrder = JSON.parse(localStorage.getItem(ROW_ORDER_KEY)); } catch (e) { rowOrder = null; }
+          var mergedOrder = mergeRowOrder(rowOrder);
+          rowOrder = mergedOrder.slice();
           var payload = {
             distanceMeasured: extractValueUnit($scope.data1),
             distanceEcu: extractValueUnit($scope.data6),
@@ -2128,7 +2220,7 @@ angular.module('beamng.apps')
             gameIsPaused: $scope.gamePaused ? 1 : 0,
             settings: {
               visible: $scope.visible,
-              rowOrder: rowOrder,
+              rowOrder: mergedOrder.length ? mergedOrder : null,
               useCustomStyles: $scope.useCustomStyles,
               unitMode: $scope.unitMode
             }

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
@@ -1,7 +1,7 @@
 {
   "name" : "Fuel Economy",
   "author": "KRtekTM",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Fuel Economy - Average Fuel Consumption",
   "directive": "okFuelEconomy",
   "domElement": "<ok-fuel-economy></ok-fuel-economy>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beamng-fuel-economy-mod",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "BeamNG fuel economy mod",
   "scripts": {
     "test": "node scripts/run-tests.js"

--- a/tests/settingsOrder.test.js
+++ b/tests/settingsOrder.test.js
@@ -1,0 +1,189 @@
+const assert = require('node:assert');
+const { describe, it } = require('node:test');
+
+function setupControllerEnvironment(savedOrder, defaultOrder) {
+  const savedGlobals = {};
+  ['angular', 'StreamsManager', 'UiUnits', 'window', 'bngApi', 'localStorage', 'performance', 'document', 'MutationObserver']
+    .forEach(key => {
+      savedGlobals[key] = Object.prototype.hasOwnProperty.call(global, key)
+        ? global[key]
+        : undefined;
+    });
+
+  let directiveDef;
+  global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };
+  global.StreamsManager = { add: () => {}, remove: () => {} };
+  global.UiUnits = { buildString: () => '' };
+  global.window = {};
+  const luaCalls = [];
+  global.bngApi = { engineLua: cmd => luaCalls.push(cmd) };
+  global.performance = { now: (() => { let t = 0; return () => { t += 16; return t; }; })() };
+
+  function createParent() {
+    const children = [];
+    return {
+      children,
+      appendChild(node) {
+        const idx = children.indexOf(node);
+        if (idx !== -1) children.splice(idx, 1);
+        children.push(node);
+        node.parentElement = this;
+      }
+    };
+  }
+
+  function createRow(id) {
+    return { id, parentElement: null };
+  }
+
+  function createSetting(id) {
+    return {
+      getAttribute(name) { return name === 'data-row' ? id : null; },
+      parentElement: null
+    };
+  }
+
+  const domMap = {};
+  const dataRows = createParent();
+  const settingsList = createParent();
+  domMap.dataRows = dataRows;
+  domMap.settingsList = settingsList;
+  domMap.heading = { style: {}, textContent: '' };
+  const settingMap = {};
+
+  defaultOrder.forEach(id => {
+    const row = createRow(id);
+    domMap[id] = row;
+    dataRows.appendChild(row);
+    const setting = createSetting(id);
+    setting.parentElement = settingsList;
+    settingMap[id] = setting;
+    settingsList.appendChild(setting);
+  });
+
+  global.document = {
+    body: {},
+    getElementById(id) {
+      return Object.prototype.hasOwnProperty.call(domMap, id) ? domMap[id] : null;
+    }
+  };
+
+  const storage = new Map();
+  if (savedOrder) storage.set('okFeRowOrder', JSON.stringify(savedOrder));
+  const storedOrders = [];
+  global.localStorage = {
+    getItem(key) {
+      return storage.has(key) ? storage.get(key) : null;
+    },
+    setItem(key, value) {
+      storage.set(key, value);
+      if (key === 'okFeRowOrder') storedOrders.push(JSON.parse(value));
+    },
+    removeItem(key) {
+      storage.delete(key);
+    }
+  };
+
+  global.MutationObserver = function (callback) {
+    this.callback = callback;
+    setupControllerEnvironment.lastObserver = this;
+  };
+  global.MutationObserver.prototype.observe = function () {};
+  global.MutationObserver.prototype.disconnect = function () {};
+
+  delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
+  require('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js');
+  const controllerFn = directiveDef.controller[directiveDef.controller.length - 1];
+  const $scope = { $on: () => {} };
+  controllerFn({ debug: () => {} }, $scope);
+
+  function cleanup() {
+    delete require.cache[require.resolve('../okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js')];
+    Object.keys(savedGlobals).forEach(key => {
+      if (savedGlobals[key] === undefined) {
+        delete global[key];
+      } else {
+        global[key] = savedGlobals[key];
+      }
+    });
+    setupControllerEnvironment.lastObserver = null;
+  }
+
+  function removeRow(id) {
+    const row = domMap[id];
+    if (!row) return;
+    const idx = dataRows.children.indexOf(row);
+    if (idx !== -1) dataRows.children.splice(idx, 1);
+    row.parentElement = null;
+    delete domMap[id];
+  }
+
+  function addRowAtStart(id) {
+    const row = createRow(id);
+    row.parentElement = dataRows;
+    dataRows.children.unshift(row);
+    domMap[id] = row;
+    return row;
+  }
+
+  return {
+    $scope,
+    dataRows,
+    settingsList,
+    settingMap,
+    storedOrders,
+    getRowIds: () => dataRows.children.map(node => node.id),
+    getSettingIds: () => settingsList.children.map(item => item.getAttribute('data-row')),
+    removeRow,
+    addRowAtStart,
+    triggerObserver: () => {
+      if (setupControllerEnvironment.lastObserver && setupControllerEnvironment.lastObserver.callback) {
+        setupControllerEnvironment.lastObserver.callback([]);
+      }
+    },
+    cleanup,
+    getSettingItem: id => settingMap[id]
+  };
+}
+
+describe('settings row order management', () => {
+  it('applies saved row order to both data rows and settings list', () => {
+    const defaultOrder = ['row-distance', 'row-fuel', 'row-range'];
+    const savedOrder = ['row-range', 'row-distance', 'row-fuel'];
+    const env = setupControllerEnvironment(savedOrder, defaultOrder);
+    try {
+      assert.deepStrictEqual(env.getRowIds(), savedOrder);
+      assert.deepStrictEqual(env.getSettingIds(), savedOrder);
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  it('allows reordering entries even when the data row is absent', () => {
+    const defaultOrder = ['row-distance', 'row-fuel', 'row-range'];
+    const env = setupControllerEnvironment(defaultOrder, defaultOrder);
+    try {
+      env.removeRow('row-fuel');
+      const target = { closest: () => env.getSettingItem('row-fuel') };
+      env.$scope.moveRow({ target }, 1);
+      assert.deepStrictEqual(env.getSettingIds(), ['row-distance', 'row-range', 'row-fuel']);
+      assert.ok(env.storedOrders.some(order => order.join(',') === 'row-distance,row-range,row-fuel'));
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  it('restores the configured order when rows reappear', () => {
+    const defaultOrder = ['row-distance', 'row-fuel', 'row-range'];
+    const savedOrder = ['row-range', 'row-distance', 'row-fuel'];
+    const env = setupControllerEnvironment(savedOrder, defaultOrder);
+    try {
+      env.removeRow('row-range');
+      env.addRowAtStart('row-range');
+      env.triggerObserver();
+      assert.deepStrictEqual(env.getRowIds(), savedOrder);
+    } finally {
+      env.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- stabilize the settings row order by managing it via a dedicated controller helper, preventing unintended mass-hiding and keeping the UI synchronized with user preferences
- ensure the web endpoint receives the sanitized row order so remote displays respect the configured ordering and visibility
- add regression tests that cover saved ordering, reordering hidden rows, and restoring ordering when rows reappear

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8bbbbe60c83298429e4495c253065