### PR TITLE
Handle BeamNG 0.37 user directory layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Data are gathered via `StreamsManager` from the *electrics* and *engineInfo* cha
 
 ## Fuel price configuration
 
-Fuel cost calculations use values stored in `AppData/Local/BeamNG.drive/{version}/settings/krtektm_fuelEconomy/fuelPrice.json`. You can change them in two ways:
+Fuel cost calculations use values stored in `AppData/Local/BeamNG.drive/{version}/settings/krtektm_fuelEconomy/fuelPrice.json` (BeamNG 0.36 and earlier) or `AppData/Local/BeamNG/BeamNG.drive/current/settings/krtektm_fuelEconomy/fuelPrice.json` (BeamNG 0.37 and newer). You can change them in two ways:
 
 1. Use the in-game fuel price dialog to set the values directly. This UI writes to the same `fuelPrice.json` file.
-2. Manually edit `fuelPrice.json` yourself (for example `C:/Users/<your user>/AppData/Local/BeamNG.drive/<version>/settings/krtektm_fuelEconomy/fuelPrice.json` on Windows) and set the values inside the `prices` object (such as `Gasoline` and `Electricity`), optionally adding a `currency` label (e.g. `$`, `€`).
+2. Manually edit `fuelPrice.json` yourself (for example `C:/Users/<your user>/AppData/Local/BeamNG/BeamNG.drive/current/settings/krtektm_fuelEconomy/fuelPrice.json` on Windows 0.37+ or the `BeamNG.drive/<version>` path on older installs) and set the values inside the `prices` object (such as `Gasoline` and `Electricity`), optionally adding a `currency` label (e.g. `$`, `€`).
 
 Existing installations using the legacy `liquidFuelPrice` and `electricityPrice` fields are upgraded automatically when the app loads.
 

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -1021,6 +1021,6 @@
             ng-attr-style="{{ 'margin-top:4px; font-size:0.8em; padding:2px 6px; cursor:pointer;' + (useCustomStyles ? ' color:#aeeaff; background:rgba(0,200,255,0.15); border:1px solid #5fdcff;' : 'color: #ff7722; border: 1px solid #ff7722;') }}">
       <span class="material-icons" ng-attr-style="{{ 'font-size:inherit; vertical-align:middle; margin-right:2px;' + (useCustomStyles ? '' : '') }}">save</span>Save
     </button><br><br>
-      <p ng-attr-style="{{ useCustomStyles ? 'margin-top:4px; color:#aeeaff; font-size: 11px; font-style: italic;' : '' }}">Fuel Economy v1.0.12</p>
+      <p ng-attr-style="{{ useCustomStyles ? 'margin-top:4px; color:#aeeaff; font-size: 11px; font-style: italic;' : '' }}">Fuel Economy v1.0.13</p>
     </div>
   </div>

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -95,6 +95,138 @@ var DEFAULT_FUEL_EMISSIONS = Object.keys(DEFAULT_CO2_FACTORS_G_PER_L).reduce(
   {}
 );
 
+function resolveUserConfigPaths(fs, pathModule, fileName) {
+  if (!fs || !pathModule) return null;
+  if (typeof process === 'undefined') return null;
+
+  function isLikelyVersionDir(dirPath) {
+    var base = pathModule.basename(dirPath || '');
+    if (base === 'current') return true;
+    if (/^\d/.test(base)) return true;
+    try {
+      var stat = fs.statSync(pathModule.join(dirPath, 'settings'));
+      if (stat && stat.isDirectory && stat.isDirectory()) return true;
+    } catch (e) {
+      // ignore missing settings directories
+    }
+    return false;
+  }
+
+  function gatherVersionDirs(baseDir) {
+    var result = [];
+    if (!baseDir) return result;
+    try {
+      var stat = fs.statSync(baseDir);
+      if (!stat || !stat.isDirectory || !stat.isDirectory()) return result;
+    } catch (e) {
+      return result;
+    }
+
+    if (isLikelyVersionDir(baseDir)) {
+      result.push(baseDir);
+      return result;
+    }
+
+    var entries;
+    try {
+      entries = fs.readdirSync(baseDir, { withFileTypes: true });
+    } catch (e) {
+      return result;
+    }
+
+    var names = [];
+    for (var i = 0; i < entries.length; i++) {
+      var entry = entries[i];
+      if (entry && entry.isDirectory && entry.isDirectory()) {
+        names.push(entry.name);
+      }
+    }
+    if (!names.length) return result;
+
+    names.sort(function (a, b) {
+      return a.localeCompare(b, undefined, { numeric: true });
+    });
+
+    var added = {};
+    function add(dir) {
+      if (!dir) return;
+      if (added[dir]) return;
+      added[dir] = true;
+      result.push(dir);
+    }
+
+    if (names.indexOf('current') !== -1) {
+      add(pathModule.join(baseDir, 'current'));
+    }
+
+    var versionNames = names.filter(function (name) {
+      return name !== 'current' && /^\d/.test(name);
+    });
+    versionNames.sort(function (a, b) {
+      return a.localeCompare(b, undefined, { numeric: true });
+    });
+    for (var j = versionNames.length - 1; j >= 0; j--) {
+      add(pathModule.join(baseDir, versionNames[j]));
+    }
+
+    var otherNames = names.filter(function (name) {
+      return name === 'current' ? false : !/^\d/.test(name);
+    });
+    otherNames.sort(function (a, b) {
+      return a.localeCompare(b, undefined, { numeric: true });
+    });
+    for (var k = otherNames.length - 1; k >= 0; k--) {
+      add(pathModule.join(baseDir, otherNames[k]));
+    }
+
+    return result;
+  }
+
+  var candidates = [];
+  var seen = {};
+  function enqueueCandidates(baseDir) {
+    var dirs = gatherVersionDirs(baseDir);
+    for (var i = 0; i < dirs.length; i++) {
+      var dir = dirs[i];
+      if (seen[dir]) continue;
+      seen[dir] = true;
+      candidates.push(dir);
+    }
+  }
+
+  var envDir = process.env && process.env.KRTEKTM_BNG_USER_DIR;
+  if (envDir) enqueueCandidates(envDir);
+
+  var userRoot;
+  if (process.platform === 'win32') {
+    userRoot = (process.env && process.env.LOCALAPPDATA) || '';
+  } else {
+    userRoot = pathModule.join(
+      (process.env && process.env.HOME) || '',
+      '.local',
+      'share',
+    );
+  }
+
+  enqueueCandidates(pathModule.join(userRoot, 'BeamNG.drive'));
+  enqueueCandidates(pathModule.join(userRoot, 'BeamNG', 'BeamNG.drive'));
+  enqueueCandidates(pathModule.join(userRoot, 'BeamNG', 'BeamNG.drive', 'current'));
+
+  if (!candidates.length) return null;
+
+  var versionDir = candidates[0];
+  var settingsDir = pathModule.join(
+    versionDir,
+    'settings',
+    'krtektm_fuelEconomy',
+  );
+  return {
+    versionDir: versionDir,
+    settingsDir: settingsDir,
+    filePath: pathModule.join(settingsDir, fileName),
+  };
+}
+
 var CO2_FACTORS_G_PER_L = Object.assign({}, DEFAULT_CO2_FACTORS_G_PER_L);
 var NOX_FACTORS_G_PER_L = Object.assign({}, DEFAULT_NOX_FACTORS_G_PER_L);
 
@@ -680,33 +812,15 @@ function loadFuelEmissionsConfig(callback) {
     try {
       const fs = require('fs');
       const path = require('path');
-      const baseDir =
-        process.env.KRTEKTM_BNG_USER_DIR ||
-        path.join(
-          process.platform === 'win32'
-            ? process.env.LOCALAPPDATA || ''
-            : path.join(process.env.HOME || '', '.local', 'share'),
-          'BeamNG.drive'
-        );
-      const versions = fs
-        .readdirSync(baseDir, { withFileTypes: true })
-        .filter(d => d.isDirectory())
-        .map(d => d.name)
-        .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
-      const latest = versions[versions.length - 1];
-      if (!latest) {
+      const paths = resolveUserConfigPaths(fs, path, 'fuelEmissions.json');
+      if (!paths) {
         applyCfg(defaults);
         if (typeof callback === 'function') callback(defaults);
         return defaults;
       }
-      const settingsDir = path.join(
-        baseDir,
-        latest,
-        'settings',
-        'krtektm_fuelEconomy'
-      );
+      const settingsDir = paths.settingsDir;
       fs.mkdirSync(settingsDir, { recursive: true });
-      const userFile = path.join(settingsDir, 'fuelEmissions.json');
+      const userFile = paths.filePath;
       loadFuelEmissionsConfig.userFile = userFile;
       let data = {};
       if (fs.existsSync(userFile)) {
@@ -821,33 +935,14 @@ function loadFuelPriceConfig(callback) {
       );
       defaults = cfg;
 
-      const baseDir =
-        process.env.KRTEKTM_BNG_USER_DIR ||
-        path.join(
-          process.platform === 'win32'
-            ? process.env.LOCALAPPDATA || ''
-            : path.join(process.env.HOME || '', '.local', 'share'),
-          'BeamNG.drive'
-        );
-
-      const versions = fs
-        .readdirSync(baseDir, { withFileTypes: true })
-        .filter(d => d.isDirectory())
-        .map(d => d.name)
-        .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
-      const latest = versions[versions.length - 1];
-      if (!latest) {
+      const paths = resolveUserConfigPaths(fs, path, 'fuelPrice.json');
+      if (!paths) {
         if (typeof callback === 'function') callback(defaults);
         return defaults;
       }
-      const settingsDir = path.join(
-        baseDir,
-        latest,
-        'settings',
-        'krtektm_fuelEconomy'
-      );
+      const settingsDir = paths.settingsDir;
       fs.mkdirSync(settingsDir, { recursive: true });
-      const userFile = path.join(settingsDir, 'fuelPrice.json');
+      const userFile = paths.filePath;
       loadFuelPriceConfig.userFile = userFile;
       if (!fs.existsSync(userFile)) {
         fs.copyFileSync(path.join(__dirname, 'fuelPrice.json'), userFile);
@@ -922,29 +1017,10 @@ function loadAvgConsumptionAlgorithm(callback) {
     try {
       const fs = require('fs');
       const path = require('path');
-      const baseDir =
-        process.env.KRTEKTM_BNG_USER_DIR ||
-        path.join(
-          process.platform === 'win32'
-            ? process.env.LOCALAPPDATA || ''
-            : path.join(process.env.HOME || '', '.local', 'share'),
-          'BeamNG.drive'
-        );
-      const versions = fs
-        .readdirSync(baseDir, { withFileTypes: true })
-        .filter(d => d.isDirectory())
-        .map(d => d.name)
-        .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
-      const latest = versions[versions.length - 1];
-      if (latest) {
-        const settingsDir = path.join(
-          baseDir,
-          latest,
-          'settings',
-          'krtektm_fuelEconomy'
-        );
-        fs.mkdirSync(settingsDir, { recursive: true });
-        const userFile = path.join(settingsDir, 'settings.json');
+      const paths = resolveUserConfigPaths(fs, path, 'settings.json');
+      if (paths) {
+        fs.mkdirSync(paths.settingsDir, { recursive: true });
+        const userFile = paths.filePath;
         let data = {};
         if (fs.existsSync(userFile)) {
           try { data = JSON.parse(fs.readFileSync(userFile, 'utf8')); } catch (e) {}
@@ -991,29 +1067,10 @@ function saveAvgConsumptionAlgorithm(algo) {
     try {
       const fs = require('fs');
       const path = require('path');
-      const baseDir =
-        process.env.KRTEKTM_BNG_USER_DIR ||
-        path.join(
-          process.platform === 'win32'
-            ? process.env.LOCALAPPDATA || ''
-            : path.join(process.env.HOME || '', '.local', 'share'),
-          'BeamNG.drive'
-        );
-      const versions = fs
-        .readdirSync(baseDir, { withFileTypes: true })
-        .filter(d => d.isDirectory())
-        .map(d => d.name)
-        .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
-      const latest = versions[versions.length - 1];
-      if (latest) {
-        const settingsDir = path.join(
-          baseDir,
-          latest,
-          'settings',
-          'krtektm_fuelEconomy'
-        );
-        fs.mkdirSync(settingsDir, { recursive: true });
-        const userFile = path.join(settingsDir, 'settings.json');
+      const paths = resolveUserConfigPaths(fs, path, 'settings.json');
+      if (paths) {
+        fs.mkdirSync(paths.settingsDir, { recursive: true });
+        const userFile = paths.filePath;
         let data = {};
         if (fs.existsSync(userFile)) {
           try { data = JSON.parse(fs.readFileSync(userFile, 'utf8')); } catch (e) {}

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
@@ -1,7 +1,7 @@
 {
   "name" : "Fuel Economy",
   "author": "KRtekTM",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Fuel Economy - Average Fuel Consumption",
   "directive": "okFuelEconomy",
   "domElement": "<ok-fuel-economy></ok-fuel-economy>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beamng-fuel-economy-mod",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "BeamNG fuel economy mod",
   "scripts": {
     "test": "node scripts/run-tests.js"

--- a/tests/avgConsumptionAlgorithm.test.js
+++ b/tests/avgConsumptionAlgorithm.test.js
@@ -57,6 +57,32 @@ describe('average consumption algorithm config', () => {
     if (prev === undefined) delete process.env.KRTEKTM_BNG_USER_DIR; else process.env.KRTEKTM_BNG_USER_DIR = prev;
   });
 
+  it('works with the BeamNG current user folder layout', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'algcur-'));
+    const base = path.join(tmp, 'BeamNG', 'BeamNG.drive');
+    const current = path.join(base, 'current');
+    fs.mkdirSync(current, { recursive: true });
+    const prev = process.env.KRTEKTM_BNG_USER_DIR;
+    process.env.KRTEKTM_BNG_USER_DIR = base;
+
+    const algo = loadAvgConsumptionAlgorithm();
+    assert.strictEqual(algo, 'optimized');
+    const settingsFile = path.join(
+      current,
+      'settings',
+      'krtektm_fuelEconomy',
+      'settings.json'
+    );
+    const data = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
+    assert.strictEqual(data.AvgConsumptionAlgorithm, 'optimized');
+
+    saveAvgConsumptionAlgorithm('direct');
+    const updated = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
+    assert.strictEqual(updated.AvgConsumptionAlgorithm, 'direct');
+
+    if (prev === undefined) delete process.env.KRTEKTM_BNG_USER_DIR; else process.env.KRTEKTM_BNG_USER_DIR = prev;
+  });
+
   it('computes average consumption directly', async () => {
     let directiveDef;
     global.angular = { module: () => ({ directive: (name, arr) => { directiveDef = arr[0](); } }) };

--- a/tests/fuelEmissionsConfig.test.js
+++ b/tests/fuelEmissionsConfig.test.js
@@ -44,4 +44,33 @@ describe('fuel emissions config', () => {
 
     delete process.env.KRTEKTM_BNG_USER_DIR;
   });
+
+  it('handles the BeamNG current user folder layout', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'emcur-'));
+    const base = path.join(tmp, 'BeamNG', 'BeamNG.drive');
+    const current = path.join(base, 'current');
+    fs.mkdirSync(current, { recursive: true });
+    const prev = process.env.KRTEKTM_BNG_USER_DIR;
+    process.env.KRTEKTM_BNG_USER_DIR = base;
+
+    const cfg = loadFuelEmissionsConfig();
+    const expected = path.join(
+      current,
+      'settings',
+      'krtektm_fuelEconomy',
+      'fuelEmissions.json'
+    );
+    assert.strictEqual(loadFuelEmissionsConfig.userFile, expected);
+    assert.ok(fs.existsSync(expected));
+    const saved = JSON.parse(fs.readFileSync(expected, 'utf8'));
+    assert.deepStrictEqual(saved, cfg);
+
+    await new Promise(r => setTimeout(r, 20));
+    ensureFuelEmissionType('BeamFuel');
+    const updated = JSON.parse(fs.readFileSync(expected, 'utf8'));
+    assert.ok(updated.BeamFuel);
+
+    if (prev === undefined) delete process.env.KRTEKTM_BNG_USER_DIR;
+    else process.env.KRTEKTM_BNG_USER_DIR = prev;
+  });
 });

--- a/tests/fuelPriceConfig.test.js
+++ b/tests/fuelPriceConfig.test.js
@@ -26,4 +26,38 @@ describe('fuel price config', () => {
     if (prev === undefined) delete process.env.KRTEKTM_BNG_USER_DIR;
     else process.env.KRTEKTM_BNG_USER_DIR = prev;
   });
+
+  it('loads config from the BeamNG current directory layout', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'fpcur-'));
+    const base = path.join(tmp, 'BeamNG', 'BeamNG.drive');
+    const current = path.join(base, 'current');
+    fs.mkdirSync(current, { recursive: true });
+    const prev = process.env.KRTEKTM_BNG_USER_DIR;
+    process.env.KRTEKTM_BNG_USER_DIR = base;
+
+    const cfg1 = loadFuelPriceConfig();
+    const expected = path.join(
+      current,
+      'settings',
+      'krtektm_fuelEconomy',
+      'fuelPrice.json'
+    );
+    assert.strictEqual(loadFuelPriceConfig.userFile, expected);
+    assert.ok(fs.existsSync(expected));
+    assert.strictEqual(cfg1.currency, 'money');
+    assert.strictEqual(cfg1.prices.Gasoline, 0);
+    assert.strictEqual(cfg1.prices.Electricity, 0);
+
+    fs.writeFileSync(
+      expected,
+      JSON.stringify({ prices: { Gasoline: 3.5, Electricity: 1.2 }, currency: 'Kč' })
+    );
+    const cfg2 = loadFuelPriceConfig();
+    assert.strictEqual(cfg2.currency, 'Kč');
+    assert.strictEqual(cfg2.prices.Gasoline, 3.5);
+    assert.strictEqual(cfg2.prices.Electricity, 1.2);
+
+    if (prev === undefined) delete process.env.KRTEKTM_BNG_USER_DIR;
+    else process.env.KRTEKTM_BNG_USER_DIR = prev;
+  });
 });

--- a/tests/webEndpoint.test.js
+++ b/tests/webEndpoint.test.js
@@ -95,6 +95,23 @@ test('payload marks paused state', () => {
   assert.strictEqual(payload.gameIsPaused, 1);
 });
 
+test('web endpoint reflects pause toggles', () => {
+  const { calls, $scope } = setup();
+  calls.length = 0;
+  $scope.on_streamsUpdate(null, { okGameState: { paused: true } });
+  let call = calls.find((c) => c.startsWith('extensions.okWebServer.setData('));
+  assert.ok(call);
+  let payload = JSON.parse(JSON.parse(call.match(/setData\((.*)\)/)[1]));
+  assert.strictEqual(payload.gameIsPaused, 1);
+
+  calls.length = 0;
+  $scope.on_streamsUpdate(null, { okGameState: { paused: false } });
+  call = calls.find((c) => c.startsWith('extensions.okWebServer.setData('));
+  assert.ok(call);
+  payload = JSON.parse(JSON.parse(call.match(/setData\((.*)\)/)[1]));
+  assert.strictEqual(payload.gameIsPaused, 0);
+});
+
 test('migrates legacy trip visibility flags', () => {
   const store = { okFuelEconomyVisible: JSON.stringify({ webEndpoint: true, tripFuelUsed: true, tripTotalCost: true, tripAvgCost: true }) };
   const { $scope } = setup(store);


### PR DESCRIPTION
## Summary
- add a shared resolver for user settings folders that works with both legacy versioned directories and the new BeamNG 0.37 `current` layout
- update fuel emission, fuel price and average consumption helpers to rely on the resolver and refresh their on-disk files accordingly
- document the dual directory layout and extend tests to cover the BeamNG `current` hierarchy

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c98658a294832990ccd2c20bce38fc