### PR TITLE
Add minimize toggle for fuel economy widget

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -1,17 +1,17 @@
 <div class="bngApp"
-     ng-attr-style="{{ (isMinimized ? 'width:100%; height:auto; overflow:visible; ' : 'width:100%; height:100%; overflow:auto; ') + 'position:relative;' + (useCustomStyles ? ' padding:4px; border-radius:10px; background-color:rgba(10,15,20,0.75); background-image:linear-gradient(rgba(0,200,255,0.05) 1px, transparent 1px), linear-gradient(90deg, rgba(0,200,255,0.05) 1px, transparent 1px); background-size:16px 16px,16px 16px; color:#aeeaff; font-family: Segoe UI, Tahoma, Geneva, Verdana, sans-serif; letter-spacing:0.3px; box-shadow: inset 0 0 10px rgba(0,200,255,0.25);' : '') }}"
+     ng-attr-style="{{ 'width:100%; position:relative; ' + (isMinimized ? 'height:auto; overflow:hidden; ' : 'height:100%; overflow:auto; ') + (useCustomStyles ? ' padding:4px; border-radius:10px; background-color:rgba(10,15,20,0.75); background-image:linear-gradient(rgba(0,200,255,0.05) 1px, transparent 1px), linear-gradient(90deg, rgba(0,200,255,0.05) 1px, transparent 1px); background-size:16px 16px,16px 16px; color:#aeeaff; font-family: Segoe UI, Tahoma, Geneva, Verdana, sans-serif; letter-spacing:0.3px; box-shadow: inset 0 0 10px rgba(0,200,255,0.25);' : '') }}"
      layout="column">
   <div ng-if="isMinimized"
        ng-click="restoreFromMinimize()"
-       ng-attr-style="{{ 'cursor:pointer; display:inline-block; margin:4px; padding:6px 10px; border-radius:6px; border:1px solid; font-weight:600; text-align:center;' + (useCustomStyles ? ' color:#aeeaff; border-color:#5fdcff; background:rgba(0,200,255,0.12); text-shadow:0 0 4px rgba(0,255,255,0.5);' : ' color:#fff; border-color:#888; background:rgba(0,0,0,0.35);') }}">
+       ng-attr-style="{{ 'cursor:pointer; display:inline-flex; align-items:center; justify-content:center; margin:4px 0 6px; padding:3px 8px; border-radius:6px; border:1px solid; font-weight:600; font-size:0.75em; letter-spacing:0.2px; text-align:center; line-height:1.2; min-width:0;' + (useCustomStyles ? ' color:#aeeaff; border-color:#5fdcff; background:rgba(0,200,255,0.08); text-shadow:0 0 4px rgba(0,255,255,0.45); box-shadow:0 0 6px rgba(0,200,255,0.18);' : ' color:#fff; border-color:#666; background:rgba(0,0,0,0.45);') }}">
     Fuel Economy (minimized)
   </div>
 
   <div ng-show="!isMinimized">
-  <strong ng-if="visible.heading"
-          ng-attr-style="{{ useCustomStyles ? 'display:block; margin:2px 0 4px; padding-left: 2px; font-size:1em; font-weight:600; color:#3fd6ff; text-shadow:0 0 5px rgba(0,255,255,0.6);' : '' }}">
-    Fuel Economy{{ gamePaused ? ' (game paused)' : '' }}: {{ vehicleNameStr }}
-  </strong>
+    <strong ng-if="visible.heading"
+            ng-attr-style="{{ useCustomStyles ? 'display:block; margin:2px 0 4px; padding-left: 2px; font-size:1em; font-weight:600; color:#3fd6ff; text-shadow:0 0 5px rgba(0,255,255,0.6);' : '' }}">
+      Fuel Economy{{ gamePaused ? ' (game paused)' : '' }}: {{ vehicleNameStr }}
+    </strong>
 
   <table ng-attr-style="{{ useCustomStyles ? 'width:100%; border-collapse:collapse; font-size:0.85em;' : '' }}">
     <tbody id="dataRows">
@@ -702,7 +702,7 @@
         ng-click="minimize($event)"
         ng-attr-style="{{ 'position:absolute; top:2px; right:4px; cursor:pointer; font-size:18px;' + (useCustomStyles ? ' color:#5fdcff; text-shadow:0 0 5px rgba(0,255,255,0.6);' : '') }}"
         ng-if="!isMinimized">
-    minimize
+    expand_more
   </span>
   <!-- Reset icon (global) -->
   <span class="material-icons"

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -1,6 +1,13 @@
 <div class="bngApp"
-     ng-attr-style="{{ 'width:100%; height:100%; overflow:auto; position:relative;' + (useCustomStyles ? ' padding:4px; border-radius:10px; background-color:rgba(10,15,20,0.75); background-image:linear-gradient(rgba(0,200,255,0.05) 1px, transparent 1px), linear-gradient(90deg, rgba(0,200,255,0.05) 1px, transparent 1px); background-size:16px 16px,16px 16px; color:#aeeaff; font-family: Segoe UI, Tahoma, Geneva, Verdana, sans-serif; letter-spacing:0.3px; box-shadow: inset 0 0 10px rgba(0,200,255,0.25);' : '') }}"
+     ng-attr-style="{{ (isMinimized ? 'width:100%; height:auto; overflow:visible; ' : 'width:100%; height:100%; overflow:auto; ') + 'position:relative;' + (useCustomStyles ? ' padding:4px; border-radius:10px; background-color:rgba(10,15,20,0.75); background-image:linear-gradient(rgba(0,200,255,0.05) 1px, transparent 1px), linear-gradient(90deg, rgba(0,200,255,0.05) 1px, transparent 1px); background-size:16px 16px,16px 16px; color:#aeeaff; font-family: Segoe UI, Tahoma, Geneva, Verdana, sans-serif; letter-spacing:0.3px; box-shadow: inset 0 0 10px rgba(0,200,255,0.25);' : '') }}"
      layout="column">
+  <div ng-if="isMinimized"
+       ng-click="restoreFromMinimize()"
+       ng-attr-style="{{ 'cursor:pointer; display:inline-block; margin:4px; padding:6px 10px; border-radius:6px; border:1px solid; font-weight:600; text-align:center;' + (useCustomStyles ? ' color:#aeeaff; border-color:#5fdcff; background:rgba(0,200,255,0.12); text-shadow:0 0 4px rgba(0,255,255,0.5);' : ' color:#fff; border-color:#888; background:rgba(0,0,0,0.35);') }}">
+    Fuel Economy (minimized)
+  </div>
+
+  <div ng-show="!isMinimized">
   <strong ng-if="visible.heading"
           ng-attr-style="{{ useCustomStyles ? 'display:block; margin:2px 0 4px; padding-left: 2px; font-size:1em; font-weight:600; color:#3fd6ff; text-shadow:0 0 5px rgba(0,255,255,0.6);' : '' }}">
     Fuel Economy{{ gamePaused ? ' (game paused)' : '' }}: {{ vehicleNameStr }}
@@ -690,28 +697,35 @@
     </tbody>
   </table>
 
+  <!-- Minimize icon -->
+  <span class="material-icons"
+        ng-click="minimize($event)"
+        ng-attr-style="{{ 'position:absolute; top:2px; right:4px; cursor:pointer; font-size:18px;' + (useCustomStyles ? ' color:#5fdcff; text-shadow:0 0 5px rgba(0,255,255,0.6);' : '') }}"
+        ng-if="!isMinimized">
+    minimize
+  </span>
   <!-- Reset icon (global) -->
   <span class="material-icons"
         ng-click="reset($event)"
-        ng-attr-style="{{ 'position:absolute; top:2px; right:4px; cursor:pointer; font-size:18px;' + (useCustomStyles ? ' color:#5fdcff; text-shadow:0 0 5px rgba(0,255,255,0.6);' : '') }}">
+        ng-attr-style="{{ 'position:absolute; top:24px; right:4px; cursor:pointer; font-size:18px;' + (useCustomStyles ? ' color:#5fdcff; text-shadow:0 0 5px rgba(0,255,255,0.6);' : '') }}">
     autorenew
   </span>
   <!-- Style toggle icon -->
   <span class="material-icons"
         ng-click="toggleCustomStyles()"
-        ng-attr-style="{{ 'position:absolute; top:24px; right:4px; cursor:pointer; font-size:18px;' + (useCustomStyles ? ' color:#5fdcff; text-shadow:0 0 5px rgba(0,255,255,0.6);' : '') }}">
+        ng-attr-style="{{ 'position:absolute; top:46px; right:4px; cursor:pointer; font-size:18px;' + (useCustomStyles ? ' color:#5fdcff; text-shadow:0 0 5px rgba(0,255,255,0.6);' : '') }}">
     palette
   </span>
   <!-- Settings icon -->
   <span class="material-icons"
         ng-click="settingsOpen=!settingsOpen"
-        ng-attr-style="{{ 'position:absolute; top:46px; right:4px; cursor:pointer; font-size:18px;' + (useCustomStyles ? ' color:#5fdcff; text-shadow:0 0 5px rgba(0,255,255,0.6);' : '') }}">
+        ng-attr-style="{{ 'position:absolute; top:68px; right:4px; cursor:pointer; font-size:18px;' + (useCustomStyles ? ' color:#5fdcff; text-shadow:0 0 5px rgba(0,255,255,0.6);' : '') }}">
     settings
   </span>
 
   <!-- Settings dialog -->
   <div ng-show="settingsOpen"
-       ng-attr-style="{{ 'position:absolute; top:68px; right:4px; z-index:10; background:rgba(0,0,0,0.85); padding:8px; border-radius:6px;' + (useCustomStyles ? ' color:#aeeaff; border:1px solid #5fdcff;' : ' color:#fff; border:1px solid #ccc; background:#333;') }}">
+       ng-attr-style="{{ 'position:absolute; top:90px; right:4px; z-index:10; background:rgba(0,0,0,0.85); padding:8px; border-radius:6px;' + (useCustomStyles ? ' color:#aeeaff; border:1px solid #5fdcff;' : ' color:#fff; border:1px solid #ccc; background:#333;') }}">
     <p id="fuelPriceNotice"
        ng-attr-style="{{ 'margin:4px 0;' + (useCustomStyles ? ' color:#aeeaff;' : '') }}">
       <a href=""
@@ -1024,3 +1038,5 @@
       <p ng-attr-style="{{ useCustomStyles ? 'margin-top:4px; color:#aeeaff; font-size: 11px; font-style: italic;' : '' }}">Fuel Economy v1.0.13</p>
     </div>
   </div>
+
+</div>

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -1035,7 +1035,7 @@
             ng-attr-style="{{ 'margin-top:4px; font-size:0.8em; padding:2px 6px; cursor:pointer;' + (useCustomStyles ? ' color:#aeeaff; background:rgba(0,200,255,0.15); border:1px solid #5fdcff;' : 'color: #ff7722; border: 1px solid #ff7722;') }}">
       <span class="material-icons" ng-attr-style="{{ 'font-size:inherit; vertical-align:middle; margin-right:2px;' + (useCustomStyles ? '' : '') }}">save</span>Save
     </button><br><br>
-      <p ng-attr-style="{{ useCustomStyles ? 'margin-top:4px; color:#aeeaff; font-size: 11px; font-style: italic;' : '' }}">Fuel Economy v1.0.13</p>
+      <p ng-attr-style="{{ useCustomStyles ? 'margin-top:4px; color:#aeeaff; font-size: 11px; font-style: italic;' : '' }}">Fuel Economy v1.0.14</p>
     </div>
   </div>
 

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -1507,6 +1507,17 @@ angular.module('beamng.apps')
         $scope.useCustomStyles = !$scope.useCustomStyles;
         try { localStorage.setItem(STYLE_KEY, $scope.useCustomStyles ? "true" : "false"); } catch (e) {}
       };
+      $scope.isMinimized = false;
+      $scope.minimize = function ($event) {
+        if ($event && typeof $event.stopPropagation === 'function') {
+          $event.stopPropagation();
+        }
+        $scope.isMinimized = true;
+        $scope.settingsOpen = false;
+      };
+      $scope.restoreFromMinimize = function () {
+        $scope.isMinimized = false;
+      };
       $scope.settingsOpen = false;
       $scope.openFuelPriceEditor = function ($event) {
         $event.preventDefault();

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
@@ -1,7 +1,7 @@
 {
   "name" : "Fuel Economy",
   "author": "KRtekTM",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Fuel Economy - Average Fuel Consumption",
   "directive": "okFuelEconomy",
   "domElement": "<ok-fuel-economy></ok-fuel-economy>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beamng-fuel-economy-mod",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "BeamNG fuel economy mod",
   "scripts": {
     "test": "node scripts/run-tests.js"

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -48,14 +48,24 @@ function parseStyle(expr) {
 describe('UI template styling', () => {
   it('toggles custom styling correctly', () => {
     const attr = getNgAttrStyle('<div class="bngApp"');
-    const { base, custom } = parseStyle(attr);
-    const styleTrue = base + custom;
+    const expr = attr.slice(3, -3);
+    const evaluate = (isMinimized, useCustomStyles) =>
+      new Function('isMinimized', 'useCustomStyles', `return ${expr};`)(isMinimized, useCustomStyles);
 
-    assert.ok(base.includes('position:relative;'));
-    assert.ok(!base.includes('background-color'));
-    assert.ok(styleTrue.includes('background-color:rgba(10,15,20,0.75);'));
-    assert.ok(styleTrue.includes('background-image:linear-gradient'));
-    assert.ok(!styleTrue.includes("url('app.png')"));
+    const defaultExpanded = evaluate(false, false);
+    const defaultMinimized = evaluate(true, false);
+    const customExpanded = evaluate(false, true);
+
+    assert.ok(defaultExpanded.includes('width:100%'));
+    assert.ok(defaultExpanded.includes('height:100%'));
+    assert.ok(defaultExpanded.includes('overflow:auto;'));
+    assert.ok(defaultExpanded.includes('position:relative;'));
+    assert.ok(!defaultExpanded.includes('background-color:rgba(10,15,20,0.75);'));
+    assert.ok(defaultMinimized.includes('height:auto;'));
+    assert.ok(defaultMinimized.includes('overflow:hidden;'));
+    assert.ok(customExpanded.includes('background-color:rgba(10,15,20,0.75);'));
+    assert.ok(customExpanded.includes('background-image:linear-gradient'));
+    assert.ok(!customExpanded.includes("url('app.png')"));
   });
 
   it('renders fuel cost bindings without inline script', () => {

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1005,18 +1005,21 @@ describe('UI template styling', () => {
     delete process.env.KRTEKTM_BNG_USER_DIR;
   });
 
-  it('positions reset, style toggle and settings icons consistently', () => {
+  it('positions minimize, reset, style toggle and settings icons consistently', () => {
+    const minimizeAttr = getNgAttrStyle('ng-click="minimize($event)"');
     const resetAttr = getNgAttrStyle('ng-click="reset($event)"');
     const toggleAttr = getNgAttrStyle('ng-click="toggleCustomStyles()"');
     const settingsAttr = getNgAttrStyle('ng-click="settingsOpen=!settingsOpen"');
+    const m = parseStyle(minimizeAttr);
     const r = parseStyle(resetAttr);
     const t = parseStyle(toggleAttr);
     const s = parseStyle(settingsAttr);
 
-    assert.ok(r.base.includes('position:absolute; top:2px; right:4px;'));
-    assert.ok(t.base.includes('position:absolute; top:24px; right:4px;'));
-    assert.ok(s.base.includes('position:absolute; top:46px; right:4px;'));
-    [r, t, s].forEach(obj => {
+    assert.ok(m.base.includes('position:absolute; top:2px; right:4px;'));
+    assert.ok(r.base.includes('position:absolute; top:24px; right:4px;'));
+    assert.ok(t.base.includes('position:absolute; top:46px; right:4px;'));
+    assert.ok(s.base.includes('position:absolute; top:68px; right:4px;'));
+    [m, r, t, s].forEach(obj => {
       assert.ok(obj.base.includes('cursor:pointer;'));
       assert.ok(obj.base.includes('font-size:18px;'));
       assert.ok(obj.custom.includes('color:#5fdcff;'));


### PR DESCRIPTION
## Summary
- add a minimized placeholder view and toggle icon to collapse the fuel economy widget
- track minimize state in the controller and restore the panel when the placeholder is clicked
- update UI tests to validate the new minimize control and adjusted icon positions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccaf94553c8329bc5d29080a1e1835