### PR TITLE
Persist minimized widget state

### DIFF
--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.html
@@ -1035,7 +1035,7 @@
             ng-attr-style="{{ 'margin-top:4px; font-size:0.8em; padding:2px 6px; cursor:pointer;' + (useCustomStyles ? ' color:#aeeaff; background:rgba(0,200,255,0.15); border:1px solid #5fdcff;' : 'color: #ff7722; border: 1px solid #ff7722;') }}">
       <span class="material-icons" ng-attr-style="{{ 'font-size:inherit; vertical-align:middle; margin-right:2px;' + (useCustomStyles ? '' : '') }}">save</span>Save
     </button><br><br>
-      <p ng-attr-style="{{ useCustomStyles ? 'margin-top:4px; color:#aeeaff; font-size: 11px; font-style: italic;' : '' }}">Fuel Economy v1.0.14</p>
+      <p ng-attr-style="{{ useCustomStyles ? 'margin-top:4px; color:#aeeaff; font-size: 11px; font-style: italic;' : '' }}">Fuel Economy v1.0.15</p>
     </div>
   </div>
 

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -1268,11 +1268,18 @@ angular.module('beamng.apps')
       var STYLE_KEY = 'okFuelEconomyUseCustomStyles';
       var PREFERRED_UNIT_KEY = 'okFuelEconomyPreferredUnit';
       var ROW_ORDER_KEY = 'okFeRowOrder';
+      var MINIMIZED_KEY = 'okFuelEconomyMinimized';
       var rowOrder = [];
       var defaultRowOrder = [];
       var rowAnchorMap = {};
       var rowObserver = null;
       var applyingRowOrder = false;
+      var storedMinimized = false;
+      try {
+        storedMinimized = localStorage.getItem(MINIMIZED_KEY) === 'true';
+      } catch (e) {
+        storedMinimized = false;
+      }
       try {
         var storedRowOrder = JSON.parse(localStorage.getItem(ROW_ORDER_KEY));
         if (Array.isArray(storedRowOrder)) rowOrder = storedRowOrder.slice();
@@ -1507,16 +1514,20 @@ angular.module('beamng.apps')
         $scope.useCustomStyles = !$scope.useCustomStyles;
         try { localStorage.setItem(STYLE_KEY, $scope.useCustomStyles ? "true" : "false"); } catch (e) {}
       };
-      $scope.isMinimized = false;
+      $scope.isMinimized = storedMinimized;
       $scope.minimize = function ($event) {
         if ($event && typeof $event.stopPropagation === 'function') {
           $event.stopPropagation();
         }
         $scope.isMinimized = true;
+        storedMinimized = true;
+        try { localStorage.setItem(MINIMIZED_KEY, 'true'); } catch (e) {}
         $scope.settingsOpen = false;
       };
       $scope.restoreFromMinimize = function () {
         $scope.isMinimized = false;
+        storedMinimized = false;
+        try { localStorage.setItem(MINIMIZED_KEY, 'false'); } catch (e) {}
       };
       $scope.settingsOpen = false;
       $scope.openFuelPriceEditor = function ($event) {

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.js
@@ -1253,12 +1253,21 @@ angular.module('beamng.apps')
         }, pollMs);
       if (emissionsTimer.unref) emissionsTimer.unref();
 
+      var removeMinimizeListeners = function () {};
+
       $scope.$on('$destroy', function () {
         StreamsManager.remove(streamsList);
         clearInterval(priceTimer);
         clearInterval(emissionsTimer);
         if (rowObserver && typeof rowObserver.disconnect === 'function') {
           rowObserver.disconnect();
+        }
+        if (typeof removeMinimizeListeners === 'function') {
+          try {
+            removeMinimizeListeners();
+          } catch (e) {
+            /* ignore */
+          }
         }
       });
 
@@ -1274,12 +1283,79 @@ angular.module('beamng.apps')
       var rowAnchorMap = {};
       var rowObserver = null;
       var applyingRowOrder = false;
+      var minimizeStateCache =
+        typeof window !== 'undefined' && window
+          ? window.__okFuelEconomyMinimizeState ||
+            (window.__okFuelEconomyMinimizeState = {})
+          : null;
       var storedMinimized = false;
-      try {
-        storedMinimized = localStorage.getItem(MINIMIZED_KEY) === 'true';
-      } catch (e) {
-        storedMinimized = false;
+
+      function readStoredMinimized() {
+        var raw = null;
+        try {
+          raw = localStorage.getItem(MINIMIZED_KEY);
+        } catch (e) {
+          raw = null;
+        }
+        if (raw === 'true') return true;
+        if (raw === 'false') return false;
+        if (
+          minimizeStateCache &&
+          typeof minimizeStateCache.minimized === 'boolean'
+        ) {
+          return minimizeStateCache.minimized;
+        }
+        return storedMinimized;
       }
+
+      function applyMinimizedState(minimized, options) {
+        var normalized = !!minimized;
+        if ($scope.isMinimized !== normalized) {
+          var apply = function () {
+            $scope.isMinimized = normalized;
+          };
+          if (typeof $scope.$evalAsync === 'function') {
+            try {
+              $scope.$evalAsync(apply);
+            } catch (e) {
+              apply();
+            }
+          } else {
+            apply();
+          }
+        }
+        storedMinimized = normalized;
+        if (minimizeStateCache && typeof minimizeStateCache === 'object') {
+          minimizeStateCache.minimized = normalized;
+        }
+        if (!options || options.persist !== false) {
+          try {
+            localStorage.setItem(
+              MINIMIZED_KEY,
+              normalized ? 'true' : 'false'
+            );
+          } catch (e) {
+            /* ignore */
+          }
+        }
+      }
+
+      function syncMinimizedFromPreference() {
+        var pref = readStoredMinimized();
+        if (pref !== storedMinimized || $scope.isMinimized !== pref) {
+          applyMinimizedState(pref, { persist: false });
+        }
+      }
+
+      storedMinimized = readStoredMinimized();
+      if (
+        minimizeStateCache &&
+        typeof minimizeStateCache === 'object' &&
+        typeof minimizeStateCache.minimized !== 'boolean'
+      ) {
+        minimizeStateCache.minimized = storedMinimized;
+      }
+      $scope.isMinimized = storedMinimized;
       try {
         var storedRowOrder = JSON.parse(localStorage.getItem(ROW_ORDER_KEY));
         if (Array.isArray(storedRowOrder)) rowOrder = storedRowOrder.slice();
@@ -1514,21 +1590,47 @@ angular.module('beamng.apps')
         $scope.useCustomStyles = !$scope.useCustomStyles;
         try { localStorage.setItem(STYLE_KEY, $scope.useCustomStyles ? "true" : "false"); } catch (e) {}
       };
-      $scope.isMinimized = storedMinimized;
       $scope.minimize = function ($event) {
         if ($event && typeof $event.stopPropagation === 'function') {
           $event.stopPropagation();
         }
-        $scope.isMinimized = true;
-        storedMinimized = true;
-        try { localStorage.setItem(MINIMIZED_KEY, 'true'); } catch (e) {}
+        applyMinimizedState(true);
         $scope.settingsOpen = false;
       };
       $scope.restoreFromMinimize = function () {
-        $scope.isMinimized = false;
-        storedMinimized = false;
-        try { localStorage.setItem(MINIMIZED_KEY, 'false'); } catch (e) {}
+        applyMinimizedState(false);
       };
+      if (
+        (typeof document !== 'undefined' &&
+          typeof document.addEventListener === 'function') ||
+        (typeof window !== 'undefined' &&
+          typeof window.addEventListener === 'function')
+      ) {
+        var minimizeSyncHandler = function () {
+          syncMinimizedFromPreference();
+        };
+        if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+          document.addEventListener('visibilitychange', minimizeSyncHandler);
+        }
+        if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+          window.addEventListener('pageshow', minimizeSyncHandler);
+          window.addEventListener('focus', minimizeSyncHandler);
+        }
+        removeMinimizeListeners = function () {
+          if (typeof document !== 'undefined' && typeof document.removeEventListener === 'function') {
+            document.removeEventListener('visibilitychange', minimizeSyncHandler);
+          }
+          if (typeof window !== 'undefined' && typeof window.removeEventListener === 'function') {
+            window.removeEventListener('pageshow', minimizeSyncHandler);
+            window.removeEventListener('focus', minimizeSyncHandler);
+          }
+        };
+      }
+      if (typeof $timeout === 'function') {
+        $timeout(syncMinimizedFromPreference, 0);
+      } else {
+        syncMinimizedFromPreference();
+      }
       $scope.settingsOpen = false;
       $scope.openFuelPriceEditor = function ($event) {
         $event.preventDefault();

--- a/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
+++ b/okFuelEconomy/ui/modules/apps/okFuelEconomy/app.json
@@ -1,7 +1,7 @@
 {
   "name" : "Fuel Economy",
   "author": "KRtekTM",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Fuel Economy - Average Fuel Consumption",
   "directive": "okFuelEconomy",
   "domElement": "<ok-fuel-economy></ok-fuel-economy>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beamng-fuel-economy-mod",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "BeamNG fuel economy mod",
   "scripts": {
     "test": "node scripts/run-tests.js"


### PR DESCRIPTION
## Summary
- store the minimized flag in localStorage and restore it when the widget loads
- update minimize and restore actions to keep the stored state in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfc264348c8329b170544a991e72be